### PR TITLE
Support JWK as key format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ The server API is generated from the open-api spec:
 
 .. code-block:: shell
 
-    oapi-codegen -generate server -package api docs/_static/nuts-service-crypto.yaml > api/generated.go
+    oapi-codegen -generate server,types -package api docs/_static/nuts-service-crypto.yaml > api/generated.go
 
 Generating mocks
 ****************

--- a/api/api.go
+++ b/api/api.go
@@ -55,15 +55,15 @@ func (w *ApiWrapper) GenerateKeyPair(ctx echo.Context, params GenerateKeyPairPar
 		}
 
 		return ctx.JSON(http.StatusOK, jwk)
-	} else {
-		// backwards compatible PEM format is the default
-		pub, err := w.C.PublicKeyInPEM(le)
-		if err != nil {
-			return err
-		}
-
-		return ctx.String(http.StatusOK, pub)
 	}
+	
+	// backwards compatible PEM format is the default
+	pub, err := w.C.PublicKeyInPEM(le)
+	if err != nil {
+		return err
+	}
+
+	return ctx.String(http.StatusOK, pub)
 }
 
 // Encrypt is the implementation of the REST service call POST /crypto/encrypt

--- a/api/api.go
+++ b/api/api.go
@@ -38,18 +38,32 @@ type ApiWrapper struct {
 }
 
 // GenerateKeyPair is the implementation of the REST service call POST /crypto/generate
+// It returns the public key for the given legal entity in either PEM or JWK format depending on the accept-header. Default is PEM (backwards compatibility)
 func (w *ApiWrapper) GenerateKeyPair(ctx echo.Context, params GenerateKeyPairParams) error {
 	le := types.LegalEntity{URI: string(params.LegalEntity)}
 	if err := w.C.GenerateKeyPairFor(le); err != nil {
 		return err
 	}
 
-	pub, err := w.C.PublicKeyInPEM(le)
-	if err != nil {
-		return err
-	}
+	acceptHeader := ctx.Request().Header.Get("Accept")
 
-	return ctx.String(http.StatusOK, pub)
+	// starts with so we can ignore any +
+	if strings.Index(acceptHeader, "application/json") == 0 {
+		jwk, err := w.C.PublicKeyInJWK(le)
+		if err != nil {
+			return err
+		}
+
+		return ctx.JSON(http.StatusOK, jwk)
+	} else {
+		// backwards compatible PEM format is the default
+		pub, err := w.C.PublicKeyInPEM(le)
+		if err != nil {
+			return err
+		}
+
+		return ctx.String(http.StatusOK, pub)
+	}
 }
 
 // Encrypt is the implementation of the REST service call POST /crypto/encrypt
@@ -325,22 +339,41 @@ func (w *ApiWrapper) Verify(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, verifyResponse)
 }
 
+// PublicKey returns a public key for the given urn. The urn represents a legal entity. The api returns the public key either in PEM or JWK format.
+// It uses the accept header to determine this. Default is PEM (text/plain), only when application/json is requested will it return JWK.
 func (w *ApiWrapper) PublicKey(ctx echo.Context, urn string) error {
 	if match, err := regexp.MatchString(`^\S+$`, urn); !match || err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "incorrect organization urn in request")
 	}
-	pubKey, err := w.C.PublicKeyInPEM(types.LegalEntity{URI: urn})
 
-	if err != nil {
-		if strings.Contains(err.Error(), "could not open private key") {
-			return ctx.NoContent(404)
+	le := types.LegalEntity{URI: urn}
+	acceptHeader := ctx.Request().Header.Get("Accept")
+
+	// starts with so we can ignore any +
+	if strings.Index(acceptHeader, "application/json") == 0 {
+		jwk, err := w.C.PublicKeyInJWK(le)
+		if err != nil {
+			if strings.Contains(err.Error(), "could not open private key") {
+				return ctx.NoContent(404)
+			}
+			logrus.Error(err.Error())
+			return err
 		}
 
-		logrus.Error(err.Error())
-		return err
-	}
+		return ctx.JSON(http.StatusOK, jwk)
+	} else {
+		// backwards compatible PEM format is the default
+		pub, err := w.C.PublicKeyInPEM(le)
+		if err != nil {
+			if strings.Contains(err.Error(), "could not open private key") {
+				return ctx.NoContent(404)
+			}
+			logrus.Error(err.Error())
+			return err
+		}
 
-	return ctx.String(200, pubKey)
+		return ctx.String(http.StatusOK, pub)
+	}
 }
 
 func readBody(ctx echo.Context) ([]byte, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -361,19 +361,19 @@ func (w *ApiWrapper) PublicKey(ctx echo.Context, urn string) error {
 		}
 
 		return ctx.JSON(http.StatusOK, jwk)
-	} else {
-		// backwards compatible PEM format is the default
-		pub, err := w.C.PublicKeyInPEM(le)
-		if err != nil {
-			if strings.Contains(err.Error(), "could not open private key") {
-				return ctx.NoContent(404)
-			}
-			logrus.Error(err.Error())
-			return err
-		}
-
-		return ctx.String(http.StatusOK, pub)
 	}
+
+	// backwards compatible PEM format is the default
+	pub, err := w.C.PublicKeyInPEM(le)
+	if err != nil {
+		if strings.Contains(err.Error(), "could not open private key") {
+			return ctx.NoContent(404)
+		}
+		logrus.Error(err.Error())
+		return err
+	}
+
+	return ctx.String(http.StatusOK, pub)
 }
 
 func readBody(ctx echo.Context) ([]byte, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -44,7 +44,7 @@ func (w *ApiWrapper) GenerateKeyPair(ctx echo.Context, params GenerateKeyPairPar
 		return err
 	}
 
-	pub, err := w.C.PublicKey(le)
+	pub, err := w.C.PublicKeyInPEM(le)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (w *ApiWrapper) PublicKey(ctx echo.Context, urn string) error {
 	if match, err := regexp.MatchString(`^\S+$`, urn); !match || err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "incorrect organization urn in request")
 	}
-	pubKey, err := w.C.PublicKey(types.LegalEntity{URI: urn})
+	pubKey, err := w.C.PublicKeyInPEM(types.LegalEntity{URI: urn})
 
 	if err != nil {
 		if strings.Contains(err.Error(), "could not open private key") {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -743,14 +743,8 @@ func TestApiWrapper_ExternalIdFor(t *testing.T) {
 
 		err := client.ExternalId(echo)
 
-		if err == nil {
-			t.Error("Expected error got nothing")
-			return
-		}
-
-		expected := "code=500, message=error getting externalId: could not open private key for legalEntity: {UNKNOWN} with filename ../../temp/VU5LTk9XTg==_private.pem"
-		if !strings.Contains(err.Error(), expected) {
-			t.Errorf("Expected error [%s], got: [%s]", expected, err.Error())
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), storage.ErrNotFound.Error())
 		}
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -78,7 +78,7 @@ func TestApiWrapper_GenerateKeyPair(t *testing.T) {
 		}
 	})
 
-	t.Run("PublicKey returns error", func(t *testing.T) {
+	t.Run("PublicKeyInPEM returns error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		cl := mock2.NewMockClient(ctrl)
@@ -93,7 +93,7 @@ func TestApiWrapper_GenerateKeyPair(t *testing.T) {
 		cl.EXPECT().GenerateKeyPairFor(le).Return(nil).AnyTimes()
 
 		// getting pub key goes boom!
-		cl.EXPECT().PublicKey(le).Return("", errors.New("boom"))
+		cl.EXPECT().PublicKeyInPEM(le).Return("", errors.New("boom"))
 
 		err := se.GenerateKeyPair(echo, GenerateKeyPairParams{LegalEntity: "test"})
 
@@ -107,7 +107,7 @@ func TestApiWrapper_Encrypt(t *testing.T) {
 	legalEntity := types.LegalEntity{URI: "test"}
 	plaintext := "for your eyes only"
 	client.C.GenerateKeyPairFor(legalEntity)
-	pemKey, _ := client.C.PublicKey(legalEntity)
+	pemKey, _ := client.C.PublicKeyInPEM(legalEntity)
 
 	t.Run("Missing body gives 400", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -154,7 +154,7 @@ func TestApiWrapper_Encrypt(t *testing.T) {
 		echo.EXPECT().Request().Return(request)
 		echo.EXPECT().JSON(http.StatusOK, gomock.Any())
 
-		client.Encrypt(echo)
+		_ = client.Encrypt(echo)
 	})
 
 	t.Run("Illegal json gives 400", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestApiWrapper_Decrypt(t *testing.T) {
 	legalEntity := types.LegalEntity{URI: "test"}
 	plaintext := "for your eyes only"
 	client.C.GenerateKeyPairFor(legalEntity)
-	pubKey, _ := client.C.PublicKey(legalEntity)
+	pubKey, _ := client.C.PublicKeyInPEM(legalEntity)
 	encRecord, _ := client.C.EncryptKeyAndPlainTextWith([]byte(plaintext), []string{pubKey})
 
 	t.Run("Decrypt API call returns 200 with decrypted message", func(t *testing.T) {
@@ -932,7 +932,7 @@ func TestDefaultCryptoEngine_Verify(t *testing.T) {
 	legalEntity := types.LegalEntity{URI: "test"}
 	client.C.GenerateKeyPairFor(legalEntity)
 
-	pemPubKey, _ := client.C.PublicKey(legalEntity)
+	pemPubKey, _ := client.C.PublicKeyInPEM(legalEntity)
 	plainText := "text"
 	base64PlainText := base64.StdEncoding.EncodeToString([]byte(plainText))
 	signature, _ := client.C.SignFor([]byte(plainText), legalEntity)
@@ -1087,7 +1087,7 @@ func TestApiWrapper_PublicKey(t *testing.T) {
 	legalEntity := types.LegalEntity{URI: "test"}
 	client.C.GenerateKeyPairFor(legalEntity)
 
-	t.Run("PublicKey API call returns 200", func(t *testing.T) {
+	t.Run("PublicKeyInPEM API call returns 200", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		echo := mock.NewMockContext(ctrl)
@@ -1097,7 +1097,7 @@ func TestApiWrapper_PublicKey(t *testing.T) {
 		client.PublicKey(echo, "test")
 	})
 
-	t.Run("PublicKey API call returns 404 for unknown", func(t *testing.T) {
+	t.Run("PublicKeyInPEM API call returns 404 for unknown", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		echo := mock.NewMockContext(ctrl)
@@ -1107,7 +1107,7 @@ func TestApiWrapper_PublicKey(t *testing.T) {
 		client.PublicKey(echo, "not")
 	})
 
-	t.Run("PublicKey API call returns 400 for empty urn", func(t *testing.T) {
+	t.Run("PublicKeyInPEM API call returns 400 for empty urn", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		echo := mock.NewMockContext(ctrl)

--- a/api/generated.go
+++ b/api/generated.go
@@ -146,7 +146,7 @@ type ServerInterface interface {
 	ExternalId(ctx echo.Context) error
 	// Send a request for checking if the given combination has valid consent// (POST /crypto/generate)
 	GenerateKeyPair(ctx echo.Context, params GenerateKeyPairParams) error
-	// get the public key for a given organization. It returns the key in PEM form// (GET /crypto/public_key/{urn})
+	// get the public key for a given organization. It returns the key in PEM or JWK form. This depends on the accept header used (text/plain vs application/json)// (GET /crypto/public_key/{urn})
 	PublicKey(ctx echo.Context, urn string) error
 	// sign a piece of data with the private key of the given legalEntity// (POST /crypto/sign)
 	Sign(ctx echo.Context) error
@@ -271,3 +271,4 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.POST("/crypto/verify", wrapper.Verify)
 
 }
+

--- a/api/generated.go
+++ b/api/generated.go
@@ -271,4 +271,3 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.POST("/crypto/verify", wrapper.Verify)
 
 }
-

--- a/docs/_static/nuts-service-crypto.yaml
+++ b/docs/_static/nuts-service-crypto.yaml
@@ -21,10 +21,17 @@ paths:
             $ref: "#/components/schemas/Identifier"
       responses:
         '200':
-          description: "OK response, body holds public key in PEM format"
+          description: "OK response, body holds public key in PEM format when accept format is text/plain and JWK format if accept equals application/json"
           content:
             text/plain:
               example: "-----BEGIN PUBLIC KEY----- .... -----END PUBLIC KEY-----"
+            application/json:
+              example: {"kty":"EC",
+                        "crv":"P-256",
+                        "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                        "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+                        "kid":"Public key used in JWS spec Appendix A.3 example"
+              }
         '400':
           description: "Invalid request"
           content:
@@ -34,7 +41,7 @@ paths:
                 type: string
   /crypto/public_key/{urn}:
     get:
-      summary: "get the public key for a given organization. It returns the key in PEM form"
+      summary: "get the public key for a given organization. It returns the key in PEM or JWK form. This depends on the accept header used (text/plain vs application/json)"
       operationId: publicKey
       tags:
         - crypto
@@ -52,6 +59,13 @@ paths:
           content:
             text/plain:
               example: "-----BEGIN PUBLIC KEY----- .... -----END PUBLIC KEY-----"
+            application/json:
+              example: {"kty":"EC",
+                        "crv":"P-256",
+                        "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                        "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+                        "kid":"Public key used in JWS spec Appendix A.3 example"
+              }
         '404':
           description: "not found"
           content:

--- a/docs/pages/development/crypto.rst
+++ b/docs/pages/development/crypto.rst
@@ -30,7 +30,7 @@ The server API is generated from the open-api spec:
 
 .. code-block:: shell
 
-    oapi-codegen -generate server -package api docs/_static/nuts-service-crypto.yaml > api/generated.go
+    oapi-codegen -generate server,types -package api docs/_static/nuts-service-crypto.yaml > api/generated.go
 
 Generating mocks
 ****************

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -126,13 +126,13 @@ func cmd() *cobra.Command {
 				cmd.Printf("Error printing publicKey: %v", err)
 				return
 			}
-			asJson, err := json.MarshalIndent(jwk, "", "  ")
+			asJSON, err := json.MarshalIndent(jwk, "", "  ")
 			if err != nil {
 				cmd.Printf("Error printing publicKey: %v\n", err)
 				return
 			}
 			cmd.Println("Public key in JWK:")
-			cmd.Println(string(asJson))
+			cmd.Println(string(asJSON))
 			cmd.Println("")
 
 			// printout in PEM

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 	"github.com/nuts-foundation/nuts-go-core/mock"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
@@ -71,101 +72,78 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 	c := pkg.CryptoInstance()
 	c.Config.Fspath = "../temp"
 	c.Configure()
+	c.GenerateKeyPairFor(types.LegalEntity{URI: "legalEntity"})
+	cmd := e.Cmd
 
 	t.Run("Cmd returns a command with a single subCommand", func(t *testing.T) {
-		cmd := e.Cmd
-		if cmd.Name() != "crypto" {
-			t.Errorf("Expected Cmd name to equal [crypto], got %s", cmd.Name())
-		}
-
-		if len(cmd.Commands()) != 3 {
-			t.Errorf("Expected Cmd to have 3 sub-command, got %d", len(cmd.Commands()))
-		}
+		assert.Equal(t, "crypto", cmd.Name())
+		assert.Len(t,  cmd.Commands(), 3)
 	})
 
 	t.Run("Running generateKeyPair with too few arguments gives error", func(t *testing.T) {
-		cmd := e.Cmd
-
 		cmd.SetArgs([]string{"generateKeyPair"})
-		cmd.SetOutput(new(bytes.Buffer))
+		cmd.SetOut(new(bytes.Buffer))
 		err := cmd.Execute()
 
-		if err == nil {
-			t.Error("Expected error, got nothing")
-		}
-
-		expected := "requires a URI argument"
-		if err.Error() != expected {
-			t.Errorf("Expected error [%s], got [%s]", expected, err.Error())
+		if assert.Error(t, err) {
+			assert.Equal(t, "requires a URI argument", err.Error())
 		}
 	})
 
 	t.Run("Running generateKeyPair returns 'keypair generated'", func(t *testing.T) {
-		cmd := e.Cmd
 		buf := new(bytes.Buffer)
 		cmd.SetArgs([]string{"generateKeyPair", "legalEntity"})
-		cmd.SetOutput(buf)
+		cmd.SetOut(buf)
 		err := cmd.Execute()
 
-		if err != nil {
-			t.Errorf("Expected no error, got [%s]", err.Error())
-		}
-
-		expected := "KeyPair generated\n"
-		if buf.String() != expected {
-			t.Errorf("Expected output [%s], got [%s]", expected, buf.String())
+		if assert.NoError(t, err) {
+			assert.Equal(t, "KeyPair generated\n", buf.String())
 		}
 	})
 
 	t.Run("Running publicKey with too few arguments gives error", func(t *testing.T) {
-		cmd := e.Cmd
-
 		cmd.SetArgs([]string{"publicKey"})
-		cmd.SetOutput(new(bytes.Buffer))
+		cmd.SetOut(new(bytes.Buffer))
 		err := cmd.Execute()
 
-		if err == nil {
-			t.Error("Expected error, got nothing")
-		}
-
-		expected := "requires a URI argument"
-		if err.Error() != expected {
-			t.Errorf("Expected error [%s], got [%s]", expected, err.Error())
+		if assert.Error(t, err) {
+			assert.Equal(t, "requires a URI argument", err.Error())
 		}
 	})
 
 	t.Run("Running publicKey returns error if public key does not exist", func(t *testing.T) {
-		cmd := e.Cmd
 		buf := new(bytes.Buffer)
 		cmd.SetArgs([]string{"publicKey", "legalEntityMissing"})
-		cmd.SetOutput(buf)
+		cmd.SetOut(buf)
 		err := cmd.Execute()
 
-		if err != nil {
-			t.Errorf("Expected no error, got [%s]", err.Error())
-		}
-
-		expected := "Error printing publicKey: could not open private key for legalEntity: {legalEntityMissing} with filename ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: open ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: no such file or directory\n"
-		if buf.String() != expected {
-			t.Errorf("Expected output [%s], got [%s]", expected, buf.String())
+		if assert.NoError(t, err) {
+			expected := "Error printing publicKey: could not open private key for legalEntity: {legalEntityMissing} with filename ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: open ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: no such file or directory"
+			assert.Contains(t, buf.String(), expected)
 		}
 	})
 
 	t.Run("Running publicKey returns pem", func(t *testing.T) {
-		c.GenerateKeyPairFor(types.LegalEntity{URI: "legalEntity"})
-		cmd := e.Cmd
 		buf := new(bytes.Buffer)
 		cmd.SetArgs([]string{"publicKey", "legalEntity"})
-		cmd.SetOutput(buf)
+		cmd.SetOut(buf)
 		err := cmd.Execute()
 
-		if err != nil {
-			t.Errorf("Expected no error, got [%s]", err.Error())
+		if assert.NoError(t, err) {
+			assert.Contains(t, buf.String(), "Public key in PEM:")
+			assert.Contains(t, buf.String(), "-----BEGIN PUBLIC KEY-----")
 		}
+	})
 
-		expected := "-----BEGIN PUBLIC KEY-----"
-		if strings.Index(buf.String(), expected) != 0 {
-			t.Errorf("Expected output to begin with [%s], got [%s]", expected, buf.String())
+	t.Run("Running publicKey returns JWK", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		cmd.SetArgs([]string{"publicKey", "legalEntity"})
+		cmd.SetOut(buf)
+		err := cmd.Execute()
+
+		if assert.NoError(t, err) {
+			assert.Contains(t, buf.String(), "Public key in JWK:")
+			assert.Contains(t, buf.String(), "kty")
 		}
 	})
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -78,7 +78,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 
 	t.Run("Cmd returns a command with a single subCommand", func(t *testing.T) {
 		assert.Equal(t, "crypto", cmd.Name())
-		assert.Len(t,  cmd.Commands(), 3)
+		assert.Len(t, cmd.Commands(), 3)
 	})
 
 	t.Run("Running generateKeyPair with too few arguments gives error", func(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nuts-foundation/nuts-go-core/mock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -82,7 +83,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 
 	t.Run("Running generateKeyPair with too few arguments gives error", func(t *testing.T) {
 		cmd.SetArgs([]string{"generateKeyPair"})
-		cmd.SetOut(new(bytes.Buffer))
+		cmd.SetOut(ioutil.Discard)
 		err := cmd.Execute()
 
 		if assert.Error(t, err) {
@@ -103,7 +104,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 
 	t.Run("Running publicKey with too few arguments gives error", func(t *testing.T) {
 		cmd.SetArgs([]string{"publicKey"})
-		cmd.SetOut(new(bytes.Buffer))
+		cmd.SetOut(ioutil.Discard)
 		err := cmd.Execute()
 
 		if assert.Error(t, err) {
@@ -118,7 +119,7 @@ func TestNewCryptoEngine_Cmd(t *testing.T) {
 		err := cmd.Execute()
 
 		if assert.NoError(t, err) {
-			expected := "Error printing publicKey: could not open private key for legalEntity: {legalEntityMissing} with filename ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: open ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: no such file or directory"
+			expected := "Error printing publicKey: could not open private key for legalEntity: legalEntityMissing with filename ../temp/bGVnYWxFbnRpdHlNaXNzaW5n_private.pem: key not found"
 			assert.Contains(t, buf.String(), expected)
 		}
 	})
@@ -156,7 +157,7 @@ func TestNewCryptoEngine_FlagSet(t *testing.T) {
 		cmd.SetArgs([]string{"--help"})
 
 		buf := new(bytes.Buffer)
-		cmd.SetOutput(buf)
+		cmd.SetOut(buf)
 
 		_, err := cmd.ExecuteC()
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/labstack/echo/v4 v4.1.11
+	github.com/lestrrat-go/jwx v0.9.0
 	github.com/magiconair/properties v1.8.0
 	github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvf
 github.com/labstack/gommon v0.2.9/go.mod h1:E8ZTmW9vw5az5/ZyHWCp0Lw4OH2ecsaBP1C/NKavGG4=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lestrrat-go/jwx v0.9.0 h1:Fnd0EWzTm0kFrBPzE/PEPp9nzllES5buMkksPMjEKpM=
+github.com/lestrrat-go/jwx v0.9.0/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
@@ -139,6 +141,8 @@ github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/square/go-jose v2.4.0+incompatible h1:moDuBePh/QZOiul3rqgI0ZnFXLaaBgcZLtLmrAfDbgo=
+github.com/square/go-jose v2.4.0+incompatible/go.mod h1:7MxpAF/1WTVUu8Am+T5kNy+t0902CaLWM4Z745MkOa8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
@@ -233,6 +237,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.4.0 h1:0kXPskUMGAXXWJlP05ktEMOV0vmzFQUWw6d+aZJQU8A=
+gopkg.in/square/go-jose.v2 v2.4.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/mock/mock_client.go
+++ b/mock/mock_client.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	jwk "github.com/lestrrat-go/jwx/jwk"
 	types "github.com/nuts-foundation/nuts-crypto/pkg/types"
 	reflect "reflect"
 )
@@ -122,19 +123,34 @@ func (mr *MockClientMockRecorder) VerifyWith(data, sig, pemKey interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyWith", reflect.TypeOf((*MockClient)(nil).VerifyWith), data, sig, pemKey)
 }
 
-// PublicKey mocks base method
-func (m *MockClient) PublicKey(legalEntity types.LegalEntity) (string, error) {
+// PublicKeyInPEM mocks base method
+func (m *MockClient) PublicKeyInPEM(legalEntity types.LegalEntity) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicKey", legalEntity)
+	ret := m.ctrl.Call(m, "PublicKeyInPEM", legalEntity)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PublicKey indicates an expected call of PublicKey
-func (mr *MockClientMockRecorder) PublicKey(legalEntity interface{}) *gomock.Call {
+// PublicKeyInPEM indicates an expected call of PublicKeyInPEM
+func (mr *MockClientMockRecorder) PublicKeyInPEM(legalEntity interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKey", reflect.TypeOf((*MockClient)(nil).PublicKey), legalEntity)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKeyInPEM", reflect.TypeOf((*MockClient)(nil).PublicKeyInPEM), legalEntity)
+}
+
+// PublicKeyInJWK mocks base method
+func (m *MockClient) PublicKeyInJWK(legalEntity types.LegalEntity) (jwk.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublicKeyInJWK", legalEntity)
+	ret0, _ := ret[0].(jwk.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PublicKeyInJWK indicates an expected call of PublicKeyInJWK
+func (mr *MockClientMockRecorder) PublicKeyInJWK(legalEntity interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKeyInJWK", reflect.TypeOf((*MockClient)(nil).PublicKeyInJWK), legalEntity)
 }
 
 // SignJwtFor mocks base method

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -18,7 +18,10 @@
 
 package pkg
 
-import "github.com/nuts-foundation/nuts-crypto/pkg/types"
+import (
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/nuts-foundation/nuts-crypto/pkg/types"
+)
 
 // CryptoClient defines the functions than can be called by a Cmd, Direct or via rest call.
 type Client interface {
@@ -34,8 +37,10 @@ type Client interface {
 	SignFor(data []byte, legalEntity types.LegalEntity) ([]byte, error)
 	// VerifyWith verifies a signature for a given PEM encoded public key
 	VerifyWith(data []byte, sig []byte, pemKey string) (bool, error)
-	// PublicKey returns the PEM encoded PublicKey for a given legal entity
-	PublicKey(legalEntity types.LegalEntity) (string, error)
+	// PublicKeyInPEM returns the PEM encoded PublicKey for a given legal entity
+	PublicKeyInPEM(legalEntity types.LegalEntity) (string, error)
+	// PublicKeyInJWK returns the JWK encoded PublicKey for a given legal entity
+	PublicKeyInJWK(legalEntity types.LegalEntity) (jwk.Key, error)
 	// SignJwtFor creates a signed JWT given a legalEntity and map of claims
 	SignJwtFor(claims map[string]interface{}, legalEntity types.LegalEntity) (string, error)
 }

--- a/pkg/crypto_test.go
+++ b/pkg/crypto_test.go
@@ -124,9 +124,7 @@ func TestCrypto_DecryptCipherTextFor(t *testing.T) {
 	t.Run("decryption for unknown legalEntity gives error", func(t *testing.T) {
 		_, err := client.decryptCipherTextFor([]byte(""), types.LegalEntity{URI: "other"})
 
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("Expected error [%v], Got [%v]", os.ErrNotExist, err)
-		}
+		assert.True(t, errors.Is(err, storage.ErrNotFound))
 	})
 }
 
@@ -140,13 +138,8 @@ func TestCrypto_encryptPlainTextFor(t *testing.T) {
 
 		_, err := client.encryptPlainTextFor([]byte(plaintext), legalEntity)
 
-		if err == nil {
-			t.Errorf("Expected error, Got nothing")
-			return
-		}
-
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("Expected error [%v], Got [%v]", os.ErrNotExist, err)
+		if assert.Error(t, err) {
+			assert.True(t, errors.Is(err, storage.ErrNotFound))
 		}
 	})
 }
@@ -207,12 +200,8 @@ func TestCrypto_DecryptKeyAndCipherTextFor(t *testing.T) {
 		}
 		_, err := client.DecryptKeyAndCipherTextFor(ct, types.LegalEntity{URI: "testU"})
 
-		if err == nil {
-			t.Errorf("Expected error, Got nothing")
-		}
-
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("Expected error [%v], Got [%v]", os.ErrNotExist, err)
+		if assert.Error(t, err) {
+			assert.True(t, errors.Is(err, storage.ErrNotFound))
 		}
 	})
 
@@ -326,12 +315,8 @@ func TestCrypto_ExternalIdFor(t *testing.T) {
 
 		_, err := client.ExternalIdFor(subject, actor, legalEntity)
 
-		if err == nil {
-			t.Errorf("Expected error, got nothing")
-		}
-
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("Expected error [%v], Got [%v]", os.ErrNotExist, err)
+		if assert.Error(t, err) {
+			assert.True(t, errors.Is(err, storage.ErrNotFound))
 		}
 	})
 
@@ -379,8 +364,9 @@ func TestCrypto_PublicKeyInPem(t *testing.T) {
 		legalEntity := types.LegalEntity{URI: "testPKUnknown"}
 		_, err := client.PublicKeyInPEM(legalEntity)
 
-		assert.NotNil(t, err)
-		assert.True(t, errors.Is(err, os.ErrNotExist))
+		if assert.Error(t, err) {
+			assert.True(t, errors.Is(err, storage.ErrNotFound))
+		}
 	})
 
 	t.Run("parse public key", func(t *testing.T) {
@@ -401,7 +387,7 @@ func TestCrypto_PublicKeyInJWK(t *testing.T) {
 	t.Run("Public key is returned from storage", func(t *testing.T) {
 		pub, err := client.PublicKeyInJWK(legalEntity)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, pub)
 		assert.Equal(t, jwa.RSA, pub.KeyType())
 	})
@@ -410,8 +396,9 @@ func TestCrypto_PublicKeyInJWK(t *testing.T) {
 		legalEntity := types.LegalEntity{URI: "testPKUnknown"}
 		_, err := client.PublicKeyInJWK(legalEntity)
 
-		assert.NotNil(t, err)
-		assert.True(t, errors.Is(err, os.ErrNotExist))
+		if assert.Error(t, err) {
+			assert.True(t, errors.Is(err, storage.ErrNotFound))
+		}
 	})
 }
 
@@ -438,7 +425,7 @@ func TestCrypto_SignJwtFor(t *testing.T) {
 	t.Run("returns error for not found", func(t *testing.T) {
 		_, err := client.SignJwtFor(map[string]interface{}{"iss": "nuts"}, types.LegalEntity{URI: "notFound"})
 
-		assert.True(t, errors.Is(err, os.ErrNotExist))
+		assert.True(t, errors.Is(err, storage.ErrNotFound))
 	})
 }
 

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 	"io/ioutil"
@@ -31,6 +32,24 @@ import (
 )
 
 const privateKeyFilePostfix = "private.pem"
+
+type FileOpenError struct {
+	filePath 	string
+	legalEntity string
+	err         error
+}
+
+var ErrNotFound = errors.New("key not found")
+
+// Error returns the string representation
+func (f *FileOpenError) Error() string {
+	return fmt.Sprintf("could not open private key for legalEntity: %v with filename %s: %v", f.legalEntity, f.filePath, f.err)
+}
+
+// UnWrap is needed for FileOpenError to be UnWrapped
+func (f *FileOpenError) Unwrap() error {
+	return f.err
+}
 
 type fileSystemBackend struct {
 	fspath string
@@ -60,7 +79,10 @@ func (fsc *fileSystemBackend) GetPrivateKey(legalEntity types.LegalEntity) (*rsa
 
 	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("could not open private key for legalEntity: %v with filename %s: %w", legalEntity, filePath, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath:filePath, err:ErrNotFound}
+		}
+		return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath:filePath, err:err}
 	}
 
 	var key *rsa.PrivateKey

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -34,7 +34,7 @@ import (
 const privateKeyFilePostfix = "private.pem"
 
 type FileOpenError struct {
-	filePath 	string
+	filePath    string
 	legalEntity string
 	err         error
 }
@@ -80,9 +80,9 @@ func (fsc *fileSystemBackend) GetPrivateKey(legalEntity types.LegalEntity) (*rsa
 	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath:filePath, err:ErrNotFound}
+			return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath: filePath, err: ErrNotFound}
 		}
-		return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath:filePath, err:err}
+		return nil, &FileOpenError{legalEntity: legalEntity.URI, filePath: filePath, err: err}
 	}
 
 	var key *rsa.PrivateKey


### PR DESCRIPTION
Using PEM formatted keys in json structures results in errors since newlines have to be added. Using JWK's solve this. It also helps in abstracting from the type of key (EC vs RSA).

Both the command line utility and the API's now support returning JWK's:

- the command line utility returns both JWK and PEM (was only PEM)
- the generateKeyPair and publicKey API's still return PEM by default
- the two API's will return JWK format when the Accept header in the http request equals `application/json`