### PR TITLE
Fixed crypto.KeyExistsFor()

### DIFF
--- a/pkg/crypto.go
+++ b/pkg/crypto.go
@@ -401,10 +401,7 @@ func (client *Crypto) SignFor(data []byte, legalEntity types.LegalEntity) ([]byt
 
 // KeyExistsFor checks storage for an entry for the given legal entity and returns true if it exists
 func (client *Crypto) KeyExistsFor(legalEntity types.LegalEntity) bool {
-	if _, err := client.Storage.GetPrivateKey(legalEntity); err != nil {
-		return false
-	}
-	return true
+	return client.Storage.KeyExistsFor(legalEntity)
 }
 
 // VerifyWith verfifies a signature of some data with a given PublicKeyInPEM. It uses the SHA256 hashing function.

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -73,6 +73,11 @@ func NewFileSystemBackend(fspath string) (*fileSystemBackend, error) {
 	return fsc, nil
 }
 
+func (fsc *fileSystemBackend) KeyExistsFor(entity types.LegalEntity) bool {
+	_, err := os.Stat(fsc.getEntryPath(entity, privateKeyFilePostfix))
+	return err == nil
+}
+
 func (fsc *fileSystemBackend) SaveCertificate(entity types.LegalEntity, certificate []byte) error {
 	filenamePath := fsc.getEntryPath(entity, certificateFilePostfix)
 	outFile, err := os.Create(filenamePath)

--- a/pkg/storage/fs_test.go
+++ b/pkg/storage/fs_test.go
@@ -147,6 +147,22 @@ func Test_fs_GetPrivateKey(t *testing.T) {
 	})
 }
 
+
+func Test_fs_KeyExistsFor(t *testing.T) {
+	entity := types.LegalEntity{URI: "Some Entity"}
+	storage := createTempStorage(t.Name())
+	defer emptyTemp(t.Name())
+
+	t.Run("non-existing entry", func(t *testing.T) {
+		assert.False(t, storage.KeyExistsFor(entity))
+	})
+	t.Run("existing entry", func(t *testing.T) {
+		key, _ := rsa.GenerateKey(rand.Reader, 2048)
+		storage.SavePrivateKey(entity, key)
+		assert.True(t, storage.KeyExistsFor(entity))
+	})
+}
+
 func createTempStorage(name string) *fileSystemBackend {
 	b, _ := NewFileSystemBackend(fmt.Sprintf("temp/%s", name))
 	return b

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -32,6 +32,7 @@ import (
 type Storage interface {
 	GetPrivateKey(legalEntity types.LegalEntity) (*rsa.PrivateKey, error)
 	GetPublicKey(legalEntity types.LegalEntity) (*rsa.PublicKey, error)
+	KeyExistsFor(legalEntity types.LegalEntity) bool
 	SavePrivateKey(legalEntity types.LegalEntity, key *rsa.PrivateKey) error
 	SaveCertificate(entity types.LegalEntity, certificate []byte) error
 	GetCertificate(entity types.LegalEntity) (*x509.Certificate, error)


### PR DESCRIPTION
Use os.Stat instead of parsing the key, leading to exists = false when the key is invalid.