### PR TITLE
Moved JWK map copying (due to internals of JWK lib) to crypto

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -88,7 +88,7 @@ func PublicKeyToPem(pub *rsa.PublicKey) (string, error) {
 	return string(pubBytes), err
 }
 
-// MapToJwk transforms a Jwk in map structure to a Jwk Key. The map structure is a typical result from json deserialization
+// MapToJwk transforms a Jwk in map structure to a Jwk Key. The map structure is a typical result from json deserialization.
 func MapToJwk(jwkAsMap map[string]interface{}) (jwk.Key, error) {
 	set, err := MapsToJwkSet([]map[string]interface{}{jwkAsMap})
 	if err != nil {
@@ -97,6 +97,7 @@ func MapToJwk(jwkAsMap map[string]interface{}) (jwk.Key, error) {
 	return set.Keys[0], nil
 }
 
+// MapsToJwkSet transforms JWKs in map structures to a JWK set, just like MapToJwk.
 func MapsToJwkSet(maps []map[string]interface{}) (*jwk.Set, error) {
 	set := &jwk.Set{}
 	var keys []interface{}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -90,15 +90,39 @@ func PublicKeyToPem(pub *rsa.PublicKey) (string, error) {
 
 // MapToJwk transforms a Jwk in map structure to a Jwk Key. The map structure is a typical result from json deserialization
 func MapToJwk(jwkAsMap map[string]interface{}) (jwk.Key, error) {
-	set := &jwk.Set{}
-	root := map[string]interface{}{}
-	root["keys"] = []interface{}{jwkAsMap}
-	if err := set.ExtractMap(root); err != nil {
+	set, err := MapsToJwkSet([]map[string]interface{}{jwkAsMap})
+	if err != nil {
 		return nil, err
 	}
 	return set.Keys[0], nil
 }
 
+func MapsToJwkSet(maps []map[string]interface{}) (*jwk.Set, error) {
+	set := &jwk.Set{}
+	var keys []interface{}
+	for _, m := range maps {
+		keys = append(keys, deepCopyMap(m))
+	}
+	root := map[string]interface{}{"keys": keys}
+	if err := set.ExtractMap(root); err != nil {
+		return set, err
+	}
+	return set, nil
+}
+
+// deepCopyMap is needed since the jwkSet.extractMap consumes the contents
+func deepCopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		vm, ok := v.(map[string]interface{})
+		if ok {
+			cp[k] = deepCopyMap(vm)
+		} else {
+			cp[k] = v
+		}
+	}
+	return cp
+}
 // JwkToMap transforms a Jwk key to a map. Can be used for json serialization
 func JwkToMap(key jwk.Key) (map[string]interface{}, error) {
 	root := map[string]interface{}{}

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -186,7 +187,6 @@ func TestMapToJwk(t *testing.T) {
 	})
 }
 
-
 func TestMapsToJwkSet(t *testing.T) {
 	t.Run("Generates set from maps", func(t *testing.T) {
 		jwkAsJSON := `{"d":"Ce3obeVsZeU3QaKBTQ-Qn-EaUfhEVViHbnP3gnLDrXNbiUf09s0Ti3RXd4601G8fAJ3zKlZmdEop59mK5BjAE8NOBmvP4uI7PYlJsDAE76mKghVxvN94qb-KwW4p0wix9RoC8TEtoE3EYCr428v-k4nTpMWXQcC_xkHVIfpoA6E","dp":"LGJtrCIxo2DlCSccu0ivH8YzUS9uUbsKyOgNEpV3IB3vqZToi_k8TkwN9XNXCMXkRYIGtRwkxvp9TWLtIEKMtQ","dq":"XhBVCRvFE_ccZ7rxzfu7LToeSNBPW07v68tM94pEV2MFfVBHdWJd-gHbIPGVwC55Th9vAh9dDmv0TvBVkiblkQ","e":"AQAB","kty":"RSA","n":"n5KqvPI1MPDhazTKXLYn4_we09e3iEccb7QJ8dRxApN1rpxTymRWabUafC56fArDF0lvIZ7fZl0LzX5Z_3mrqulebEPTFRrbdDwwcqa2KZ7Tctfh6MgUFm5xOAwRG33NlX3Ny1dP-Ek2irXJOHt9AecbEZFZKmpgrsrTyG6Ekfs","p":"1LoOk3MFiJpsjJCkMkaDb0TXXMxuZ5f9-iMVgR1ZoammzQziBj-72CrD21Rxmuuc6en8w4HtHLSOlPQtcOKzMw","q":"wAiSzr1NVdsYulhGYAa1ONZSKVxlFS7N_UAjPQgFf-xTYog2RbZfolheDv92mJp2qqFJdVMzQkbeMeTj9xqmGQ","qi":"eFqCOgR0wnpkjZGwh63pV8aNhh1-GfhYjqF2jSrh6rnsVHnhz3LRROSzUDarms7LjW3eHiygyHHSF2-ejTMMKQ"}`
@@ -252,4 +252,19 @@ func TestMapToX509CertChain(t *testing.T) {
 		}
 		assert.Len(t, chain, 1)
 	})
+}
+
+func Test_deepCopyMap(t *testing.T) {
+	expected := map[string]interface{}{}
+	expected["flat"] = "foobar"
+	expected["nested"] = map[string]interface{}{
+		"nested": map[string]interface{}{
+			"nested": map[string]interface{}{
+				"value": "ok",
+			},
+		},
+	}
+
+	actual := deepCopyMap(expected)
+	assert.True(t, reflect.DeepEqual(actual, expected))
 }

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -267,4 +267,7 @@ func Test_deepCopyMap(t *testing.T) {
 
 	actual := deepCopyMap(expected)
 	assert.True(t, reflect.DeepEqual(actual, expected))
+	// Assert it's actually a copy
+	delete(expected, "flat")
+	assert.False(t, reflect.DeepEqual(actual, expected))
 }

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -171,14 +171,41 @@ func TestMapToJwk(t *testing.T) {
 
 		jwk, err := MapToJwk(jwkMap)
 
-		if assert.NoError(t, err) {
-			assert.Equal(t, jwa.KeyType("RSA"), jwk.KeyType())
+		if !assert.NoError(t, err) {
+			return
 		}
+		assert.Equal(t, jwa.KeyType("RSA"), jwk.KeyType())
+		assert.NotNil(t, jwkMap["d"], "function altered input map")
 	})
 
 	t.Run("with missing data", func(t *testing.T) {
 		jwkMap := map[string]interface{}{}
 		_, err := MapToJwk(jwkMap)
+
+		assert.Error(t, err)
+	})
+}
+
+
+func TestMapsToJwkSet(t *testing.T) {
+	t.Run("Generates set from maps", func(t *testing.T) {
+		jwkAsJSON := `{"d":"Ce3obeVsZeU3QaKBTQ-Qn-EaUfhEVViHbnP3gnLDrXNbiUf09s0Ti3RXd4601G8fAJ3zKlZmdEop59mK5BjAE8NOBmvP4uI7PYlJsDAE76mKghVxvN94qb-KwW4p0wix9RoC8TEtoE3EYCr428v-k4nTpMWXQcC_xkHVIfpoA6E","dp":"LGJtrCIxo2DlCSccu0ivH8YzUS9uUbsKyOgNEpV3IB3vqZToi_k8TkwN9XNXCMXkRYIGtRwkxvp9TWLtIEKMtQ","dq":"XhBVCRvFE_ccZ7rxzfu7LToeSNBPW07v68tM94pEV2MFfVBHdWJd-gHbIPGVwC55Th9vAh9dDmv0TvBVkiblkQ","e":"AQAB","kty":"RSA","n":"n5KqvPI1MPDhazTKXLYn4_we09e3iEccb7QJ8dRxApN1rpxTymRWabUafC56fArDF0lvIZ7fZl0LzX5Z_3mrqulebEPTFRrbdDwwcqa2KZ7Tctfh6MgUFm5xOAwRG33NlX3Ny1dP-Ek2irXJOHt9AecbEZFZKmpgrsrTyG6Ekfs","p":"1LoOk3MFiJpsjJCkMkaDb0TXXMxuZ5f9-iMVgR1ZoammzQziBj-72CrD21Rxmuuc6en8w4HtHLSOlPQtcOKzMw","q":"wAiSzr1NVdsYulhGYAa1ONZSKVxlFS7N_UAjPQgFf-xTYog2RbZfolheDv92mJp2qqFJdVMzQkbeMeTj9xqmGQ","qi":"eFqCOgR0wnpkjZGwh63pV8aNhh1-GfhYjqF2jSrh6rnsVHnhz3LRROSzUDarms7LjW3eHiygyHHSF2-ejTMMKQ"}`
+
+		jwkMap := map[string]interface{}{}
+		json.Unmarshal([]byte(jwkAsJSON), &jwkMap)
+
+		set, err := MapsToJwkSet([]map[string]interface{}{jwkMap})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, set.Keys, 1)
+		assert.NotNil(t, jwkMap["d"], "function altered input map")
+	})
+
+	t.Run("with missing data", func(t *testing.T) {
+		jwkMap := map[string]interface{}{}
+		_, err := MapsToJwkSet([]map[string]interface{}{jwkMap})
 
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
The fact that we need to copy the JWK source map before converting it to a JWK is an internal feature/quirk of the JWK library we're using. As such it needs to be a concern of crypto and not of every module using crypto.