### PR TITLE
Added JWS support in SignFor() and VerifyWith()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ Key                                     Default                 Description
 crypto.storage                          fs                      storage to use, 'fs' for file system
 crypto.fspath                           .                       when file system is used as storage, this configures the path where keys are stored
 crypto.keysize                          2048                    number of bits to use when creating new RSA keys
+crypto.signature                        plain-rsa               signature format to use when signing data (options: plain-rsa, jws)
+                                                                'plain-rsa' is the format currently in use but since we want to migrate to JWS
+                                                                in future 'jws' was added. You should not switch to 'jws' unless everyone else
+                                                                in the network supports it.
 ===================================     ====================    ================================================================================
 
 As with all other properties for nuts-go, they can be set through yaml:

--- a/docs/pages/configuration/crypto.rst
+++ b/docs/pages/configuration/crypto.rst
@@ -13,6 +13,10 @@ Key                                     Default                 Description
 crypto.storage                          fs                      storage to use, 'fs' for file system
 crypto.fspath                           .                       when file system is used as storage, this configures the path where keys are stored
 crypto.keysize                          2048                    number of bits to use when creating new RSA keys
+crypto.signature                        plain-rsa               signature format to use when signing data (options: plain-rsa, jws)
+                                                                'plain-rsa' is the format currently in use but since we want to migrate to JWS
+                                                                in future 'jws' was added. You should not switch to 'jws' unless everyone else
+                                                                in the network supports it.
 ===================================     ====================    ================================================================================
 
 As with all other properties for nuts-go, they can be set through yaml:

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -21,6 +21,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -57,6 +58,7 @@ func flagSet() *pflag.FlagSet {
 	flags.String(types.ConfigStorage, types.ConfigStorageFs, "storage to use, 'fs' for file system (default)")
 	flags.String(types.ConfigFSPath, types.ConfigFSPathDefault, "when file system is used as storage, this configures the path where keys are stored (default .)")
 	flags.Int(types.ConfigKeySize, types.ConfigKeySizeDefault, "number of bits to use when creating new RSA keys")
+	flags.String(types.ConfigSignatureFormat, types.ConfigSignatureFormatDefault, fmt.Sprintf("signature format to use when signing (%s, %s)", types.SignatureFormatPlainRSA, types.SignatureFormatJWS))
 
 	return flags
 }

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,10 @@ require (
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/lestrrat-go/jwx v0.9.1
 	github.com/magiconair/properties v1.8.1
-	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/nuts-foundation/nuts-go-core v0.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d // indirect
-	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 )

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -37,6 +37,17 @@ const ConfigKeySize string = "keysize"
 // default setting for --keysize "2048"
 const ConfigKeySizeDefault int = 2048
 
+// ConfigSignatureFormat defines --signature config flag
+const ConfigSignatureFormat = "signature"
+
+// ConfigSignatureFormatDefault holds the default value for ConfigSignatureFormat
+const ConfigSignatureFormatDefault = SignatureFormatPlainRSA
+
+const (
+	SignatureFormatPlainRSA = "plain-rsa"
+	SignatureFormatJWS      = "jws"
+)
+
 // type identifying the legalEntity responsible for the Patient/medical data
 type LegalEntity struct {
 	URI string


### PR DESCRIPTION
Fixes #15 

Change is backwards and forwards compatible:
- SignFor() supports current plain RSA and JWS, but defaults to plain RSA
- VerifyWith() supports both plain RSA and JWS