### PR TITLE
added GetExpiringCertificates to storage interface

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cert/util.go
+++ b/pkg/cert/util.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
-	"fmt"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	core "github.com/nuts-foundation/nuts-go-core"
@@ -39,7 +38,7 @@ var ErrWrongPublicKey = core.NewError("failed to decode PEM block containing pub
 var ErrRsaPubKeyConversion = core.NewError("Unable to convert public key to RSA public key", false)
 
 // ErrWrongPublicKey indicates a wrong certificate format
-var ErrWrongCertificate = core.NewError("failed to decode PEM block containing certificate", false)
+var ErrInvalidCertificate = core.NewError("failed to decode PEM block containing certificate", false)
 
 // PemToPublicKey converts a PEM encoded public key to an rsa.PublicKeyInPEM
 func PemToPublicKey(pub []byte) (*rsa.PublicKey, error) {
@@ -192,10 +191,10 @@ func GetX509ChainFromHeaders(headers jwkHeaderReader) ([]*x509.Certificate, erro
 func PemToX509(rawData []byte) (*x509.Certificate, error) {
 	block, rest := pem.Decode(rawData)
 	if len(rest) > 0 {
-		return nil, fmt.Errorf("found %d rest bytes after decoding PEM", len(rest))
+		return nil, errors2.Wrapf(ErrInvalidCertificate, "found %d rest bytes after decoding PEM", len(rest))
 	}
 	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, ErrWrongCertificate
+		return nil, ErrInvalidCertificate
 	}
 	return x509.ParseCertificate(block.Bytes)
 }

--- a/pkg/cert/util_test.go
+++ b/pkg/cert/util_test.go
@@ -292,7 +292,7 @@ func TestPemToX509(t *testing.T) {
 
 		_, err := PemToX509(pemCopy)
 		if assert.Error(t, err) {
-			assert.Equal(t, "found 1 rest bytes after decoding PEM", err.Error())
+			assert.True(t, strings.Contains(err.Error(), ErrInvalidCertificate.Error()))
 		}
 	})
 }

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -182,14 +182,14 @@ func (fsc *fileSystemBackend) GetExpiringCertificates(from time.Time, till time.
 	err := filepath.Walk(fsc.fspath, func(path string, info os.FileInfo, err error) error {
 		// only target expiringCertificates
 		if strings.Contains(info.Name(), string(certificateEntry)) {
-			x509, err := fsc.readCertificate(path)
+			certificate, err := fsc.readCertificate(path)
 			if err != nil {
 				return errors2.Wrap(err, fmt.Sprintf("error parsing file at %s", path))
 			}
 
 			// check if not_after is between from and till
-			if x509.NotAfter.After(from) && x509.NotAfter.Before(till) {
-				expiringCertificates = append(expiringCertificates, x509)
+			if certificate.NotAfter.After(from) && certificate.NotAfter.Before(till) {
+				expiringCertificates = append(expiringCertificates, certificate)
 			}
 		}
 		return nil

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -26,16 +26,22 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	"github.com/nuts-foundation/nuts-crypto/pkg/types"
+	errors2 "github.com/pkg/errors"
 )
 
 type entryType string
+
 const (
 	certificateEntry entryType = "certificate.pem"
-	privateKeyEntry entryType = "private.pem"
+	privateKeyEntry  entryType = "private.pem"
 )
 
 type FileOpenError struct {
@@ -46,6 +52,9 @@ type FileOpenError struct {
 
 // ErrNotFound indicates that the specified crypto storage entry couldn't be found.
 var ErrNotFound = errors.New("entry not found")
+
+// ErrInvalidDuration is given when a period duration is 0 or negative
+var ErrInvalidDuration = errors.New("given time period is invalid")
 
 // Error returns the string representation
 func (f *FileOpenError) Error() string {
@@ -106,11 +115,15 @@ func (fsc *fileSystemBackend) GetCertificate(key types.KeyIdentifier) (*x509.Cer
 	if err != nil {
 		return nil, err
 	}
-	asn1bytes, rest := pem.Decode(rawData)
-	if len(rest) > 0 {
-		return nil, fmt.Errorf("found %d rest bytes after decoding PEM", len(rest))
+	return cert.PemToX509(rawData)
+}
+
+func (fsc *fileSystemBackend) readCertificate(filePath string) (*x509.Certificate, error) {
+	rawData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
 	}
-	return x509.ParseCertificate(asn1bytes.Bytes)
+	return cert.PemToX509(rawData)
 }
 
 // Load the privatekey for the given legalEntity from disk. Since a legalEntity has a URI as identifier, the URI is base64 encoded and postfixed with '_private.pem'. Keys are stored in pem format and are 2k RSA keys.
@@ -154,6 +167,37 @@ func (fsc *fileSystemBackend) SavePrivateKey(keyIdentifier types.KeyIdentifier, 
 	err = pem.Encode(outFile, privateKey)
 
 	return err
+}
+
+// GetExpiringCertificates naive implementation, uses the fileTree to check every certificate
+// it'll not group certificates based on legalEntity. This is up to a more robust implementation
+func (fsc *fileSystemBackend) GetExpiringCertificates(from time.Time, till time.Time) ([]*x509.Certificate, error) {
+	if from.Equal(till) || from.After(till) {
+		return nil, ErrInvalidDuration
+	}
+
+	var expiringCertificates = make([]*x509.Certificate, 0)
+
+	// list all files ending on certificateEntry in fcs.path
+	err := filepath.Walk(fsc.fspath, func(path string, info os.FileInfo, err error) error {
+		// only target expiringCertificates
+		if strings.Contains(info.Name(), string(certificateEntry)) {
+			x509, err := fsc.readCertificate(path)
+			if err != nil {
+				return errors2.Wrap(err, fmt.Sprintf("error parsing file at %s", path))
+			}
+
+			// check if not_after is between from and till
+			if x509.NotAfter.After(from) && x509.NotAfter.Before(till) {
+				expiringCertificates = append(expiringCertificates, x509)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return expiringCertificates, nil
 }
 
 func (fsc fileSystemBackend) readEntry(key types.KeyIdentifier, entryType entryType) ([]byte, error) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -39,7 +39,8 @@ type Storage interface {
 	SaveCertificate(key types.KeyIdentifier, certificate []byte) error
 	GetCertificate(key types.KeyIdentifier) (*x509.Certificate, error)
 	CertificateExists(key types.KeyIdentifier) bool
-	// GetExpiringCertificates lists all certificates will expire between given times
+	// GetExpiringCertificates lists all certificates that will expire between given times.
+	// Till must be > from, otherwise an error is returned.
 	GetExpiringCertificates(from time.Time, till time.Time) ([]*x509.Certificate, error)
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,6 +25,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"time"
+
 	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 )
 
@@ -37,6 +39,8 @@ type Storage interface {
 	SaveCertificate(key types.KeyIdentifier, certificate []byte) error
 	GetCertificate(key types.KeyIdentifier) (*x509.Certificate, error)
 	CertificateExists(key types.KeyIdentifier) bool
+	// GetExpiringCertificates lists all certificates will expire between given times
+	GetExpiringCertificates(from time.Time, till time.Time) ([]*x509.Certificate, error)
 }
 
 // shared function to convert bytes to a RSA private key


### PR DESCRIPTION
The fs implementation is simple and does not check overlapping certs to use the newest and ignore the current expiring. This is something for a better implementation with Vault and/or SQL