### PR TITLE
Let TrustStore.GetCertificates filter out partial chains with only roots and intermediates

### DIFF
--- a/pkg/cert/truststore.go
+++ b/pkg/cert/truststore.go
@@ -94,16 +94,18 @@ func (m *fileTrustStore) GetRoots(moment time.Time) []*x509.Certificate {
 func (m *fileTrustStore) GetCertificates(chain [][]*x509.Certificate, moment time.Time, isCA bool) [][]*x509.Certificate {
 	var certs [][]*x509.Certificate
 	pool := x509.NewCertPool()
+	rootsAndIntermediates := map[*x509.Certificate]bool{}
 
 	// construct pool with signers and its signers
 	for _, subChain := range chain {
 		for _, c := range subChain {
 			pool.AddCert(c)
+			rootsAndIntermediates[c] = true
 		}
 	}
 
 	for _, c := range m.certs {
-		if c.IsCA == isCA {
+		if c.IsCA == isCA && !rootsAndIntermediates[c] {
 			chain, err := c.Verify(x509.VerifyOptions{Roots: pool, CurrentTime: moment})
 			if err == nil {
 				for _, subChain := range chain {

--- a/pkg/cert/truststore.go
+++ b/pkg/cert/truststore.go
@@ -26,6 +26,8 @@ type TrustStore interface {
 	// GetRoots returns all roots active at the given time
 	GetRoots(time.Time) []*x509.Certificate
 	// GetCertificates returns all certificates signed by given signer chains, active at the given time and if it must be a CA
+	// The chain is returned in reverse order, the latest in the chain being the root. This is also the order the certificates in the chain
+	// param are expected
 	GetCertificates([][]*x509.Certificate, time.Time, bool) [][]*x509.Certificate
 }
 
@@ -100,7 +102,7 @@ func (m *fileTrustStore) GetCertificates(chain [][]*x509.Certificate, moment tim
 	// construct roots with signers and its signers
 	for _, subChain := range chain {
 		for i, c := range subChain {
-			if i == 0 {
+			if i == len(subChain)-1 {
 				roots.AddCert(c)
 			} else {
 				intermediates.AddCert(c)

--- a/pkg/cert/truststore_test.go
+++ b/pkg/cert/truststore_test.go
@@ -220,6 +220,7 @@ func Test_fileTrustStore_GetCertificates(t *testing.T) {
 
 		certs := trustStore.GetCertificates(chains, time.Now(), false)
 		assert.Len(t, certs, 1)
+		assert.Len(t, certs[0], 2)
 
 		// but not as CA
 		certs = trustStore.GetCertificates(chains, time.Now(), true)
@@ -283,11 +284,13 @@ func generateSelfSignedsCertificate(commonName string, notBefore time.Time, vali
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
-		PublicKey:   privKey.PublicKey,
-		NotBefore:   notBefore,
-		NotAfter:    notBefore.AddDate(0, 0, validityInDays),
-		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		PublicKey:             privKey.PublicKey,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.AddDate(0, 0, validityInDays),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
 	}
 	data, err := x509.CreateCertificate(rand.Reader, &template, &template, privKey.Public(), privKey)
 	if err != nil {


### PR DESCRIPTION
fixes #72