### PR TITLE
Add SignJWS() func for signing JWS's with non-ephemeral keys

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -149,7 +149,7 @@ func testResponseCode(expectedStatusCode int, response *http.Response) error {
 	return nil
 }
 
-func (hb HttpClient) SignJWS(payload []byte, entity types.LegalEntity) ([]byte, error) {
+func (hb HttpClient) SignJWS(payload []byte, key types.KeyIdentifier) ([]byte, error) {
 	panic(ErrNotImplemented)
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -217,7 +217,7 @@ func TestHttpClient_NonImplemented(t *testing.T) {
 			c.SignJWSEphemeral(nil, nil, x509.CertificateRequest{}, time.Now())
 		},
 		"SignJWS": func() {
-			c.SignJWS(nil, types.LegalEntity{})
+			c.SignJWS(nil, nil)
 		},
 		"VerifyJWS": func() {
 			c.VerifyJWS(nil, time.Now(), nil)

--- a/pkg/cert/csr.go
+++ b/pkg/cert/csr.go
@@ -11,9 +11,9 @@ import (
 
 
 var OIDSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
-var oidNuts = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 54851}
-var OIDNutsVendor = asn12.OIDAppend(oidNuts, 4)
-var oidNutsDomain = asn12.OIDAppend(oidNuts, 3)
+var OIDNuts = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 54851}
+var OIDNutsVendor = asn12.OIDAppend(OIDNuts, 4)
+var OIDNutsDomain = asn12.OIDAppend(OIDNuts, 3)
 
 // VendorCertificateRequest creates a CertificateRequest template for issuing a vendor certificate.
 //   vendorID:      URN-OID-encoded ID of the vendor
@@ -45,7 +45,7 @@ func VendorCertificateRequest(vendorID string, vendorName string, qualifier stri
 	if err != nil {
 		return nil, err
 	}
-	extensions = append(extensions, pkix.Extension{Id: oidNutsDomain, Critical: false, Value: domainData})
+	extensions = append(extensions, pkix.Extension{Id: OIDNutsDomain, Critical: false, Value: domainData})
 
 	commonName := vendorName
 	if qualifier != "" {

--- a/pkg/cert/util.go
+++ b/pkg/cert/util.go
@@ -254,12 +254,25 @@ func IsCA() CertificateValidator {
 }
 
 func ValidateCertificate(certificate *x509.Certificate, validators ...CertificateValidator) error {
+	if certificate == nil {
+		return errors.New("certificate is nil")
+	}
 	for _, validator := range validators {
 		if err := validator(certificate); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// MeantForSigning validates whether the certificate is meant for signing (key usage includes digitalSignature and/or contentCommitment)
+func MeantForSigning() CertificateValidator {
+	return func(certificate *x509.Certificate) error {
+		if certificate.KeyUsage&x509.KeyUsageDigitalSignature != x509.KeyUsageDigitalSignature && certificate.KeyUsage&x509.KeyUsageContentCommitment != x509.KeyUsageContentCommitment {
+			return errors.New("certificate is not meant for signing (keyUsage = digitalSignature | contentCommitment)")
+		}
+		return nil
+	}
 }
 
 func unmarshalX509CertChain(chain []string) ([]*x509.Certificate, error) {

--- a/pkg/cert/x509_test.go
+++ b/pkg/cert/x509_test.go
@@ -43,7 +43,7 @@ func TestGetActiveCertificates(t *testing.T) {
 		assert.Empty(t, certificates)
 	})
 	t.Run("single entry", func(t *testing.T) {
-		certBytes := test.GenerateCertificateEx(time.Now().AddDate(0, 0, -1), 2, rsaKey)
+		certBytes := test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 2, rsaKey)
 		cert, err := x509.ParseCertificate(certBytes)
 		if !assert.NoError(t, err) {
 			return
@@ -59,10 +59,10 @@ func TestGetActiveCertificates(t *testing.T) {
 		// cert3 is valid, and longer than cert2
 		// cert4 is not valid yet
 		// Expected result: cert3, cert2
-		cert1, _ := x509.ParseCertificate(test.GenerateCertificateEx(time.Now().AddDate(0, 0, -5), 1, rsaKey))
-		cert2, _ := x509.ParseCertificate(test.GenerateCertificateEx(time.Now().AddDate(0, 0, -1), 3, rsaKey))
-		cert3, _ := x509.ParseCertificate(test.GenerateCertificateEx(time.Now().AddDate(0, 0, -1), 4, rsaKey))
-		cert4, _ := x509.ParseCertificate(test.GenerateCertificateEx(time.Now().AddDate(0, 0, 1), 1, rsaKey))
+		cert1, _ := x509.ParseCertificate(test.GenerateCertificate(time.Now().AddDate(0, 0, -5), 1, rsaKey))
+		cert2, _ := x509.ParseCertificate(test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 3, rsaKey))
+		cert3, _ := x509.ParseCertificate(test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 4, rsaKey))
+		cert4, _ := x509.ParseCertificate(test.GenerateCertificate(time.Now().AddDate(0, 0, 1), 1, rsaKey))
 		key1, _ := jwk.New(rsaKey)
 		key1.Set(jwk.X509CertChainKey, base64.StdEncoding.EncodeToString(cert1.Raw))
 		key2, _ := jwk.New(rsaKey)

--- a/pkg/crypto.go
+++ b/pkg/crypto.go
@@ -99,8 +99,8 @@ const TLSCertificateValidityInDays = 365
 // SigningCertificateValidityInDays holds the number of days issued signing certificates are valid
 const SigningCertificateValidityInDays = 365
 
-const tlsCertificateQualifier = "tls"
-const signingCertificateQualifier = "sign"
+const TLSCertificateQualifier = "tls"
+const SigningCertificateQualifier = "sign"
 
 type CryptoConfig struct {
 	Mode          string
@@ -255,24 +255,24 @@ func (client *Crypto) GenerateVendorCACSR(name string) ([]byte, error) {
 }
 
 func (client *Crypto) GetSigningCertificate(entity types.LegalEntity) (*x509.Certificate, crypto.PrivateKey, error) {
-	key := types.KeyForEntity(entity).WithQualifier(signingCertificateQualifier)
+	key := types.KeyForEntity(entity).WithQualifier(SigningCertificateQualifier)
 	return client.getCertificateAndKey(key)
 }
 
 func (client *Crypto) RenewSigningCertificate(entity types.LegalEntity) (*x509.Certificate, crypto.PrivateKey, error) {
-	return client.issueSubCertificate(entity, signingCertificateQualifier, CertificateProfile{
+	return client.issueSubCertificate(entity, SigningCertificateQualifier, CertificateProfile{
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageContentCommitment,
 		NumDaysValid: SigningCertificateValidityInDays,
 	})
 }
 
 func (client *Crypto) GetTLSCertificate(entity types.LegalEntity) (*x509.Certificate, crypto.PrivateKey, error) {
-	key := types.KeyForEntity(entity).WithQualifier(tlsCertificateQualifier)
+	key := types.KeyForEntity(entity).WithQualifier(TLSCertificateQualifier)
 	return client.getCertificateAndKey(key)
 }
 
 func (client *Crypto) RenewTLSCertificate(entity types.LegalEntity) (*x509.Certificate, crypto.PrivateKey, error) {
-	return client.issueSubCertificate(entity, tlsCertificateQualifier, CertificateProfile{
+	return client.issueSubCertificate(entity, TLSCertificateQualifier, CertificateProfile{
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		NumDaysValid: TLSCertificateValidityInDays,

--- a/pkg/crypto_test.go
+++ b/pkg/crypto_test.go
@@ -800,9 +800,9 @@ func TestCrypto_GetSigningCertificate(t *testing.T) {
 		assert.NotNil(t, privateKey)
 	})
 	t.Run("ok - exists but expired", func(t *testing.T) {
-		privateKey, _ := client.generateAndStoreKeyPair(key.WithQualifier(signingCertificateQualifier))
+		privateKey, _ := client.generateAndStoreKeyPair(key.WithQualifier(SigningCertificateQualifier))
 		certificateAsASN1 := test.GenerateCertificate(time.Now().AddDate(-1, 0, 0), 1, privateKey)
-		client.Storage.SaveCertificate(key.WithQualifier(signingCertificateQualifier), certificateAsASN1)
+		client.Storage.SaveCertificate(key.WithQualifier(SigningCertificateQualifier), certificateAsASN1)
 		certificate, pk, err := client.GetSigningCertificate(entity)
 		if !assert.NoError(t, err) {
 			return
@@ -815,7 +815,7 @@ func TestCrypto_GetSigningCertificate(t *testing.T) {
 		key2 := types.KeyForEntity(entity2)
 		privateKey, _ := client.generateKeyPair()
 		certificateAsASN1 := test.GenerateCertificate(time.Now(), 1, privateKey)
-		client.Storage.SaveCertificate(key2.WithQualifier(signingCertificateQualifier), certificateAsASN1)
+		client.Storage.SaveCertificate(key2.WithQualifier(SigningCertificateQualifier), certificateAsASN1)
 		certificate, pk, err := client.GetSigningCertificate(entity2)
 		assert.EqualError(t, err, "unable to retrieve private key for certificate: [foobar2|sign]: could not open entry [foobar2|sign] with filename temp/TestCrypto_GetSigningCertificate/Zm9vYmFyMg==_sign_private.pem: entry not found")
 		assert.Nil(t, certificate)

--- a/pkg/crypto_test.go
+++ b/pkg/crypto_test.go
@@ -466,6 +466,23 @@ type poolCertVerifier struct {
 	pool *x509.CertPool
 }
 
+func (n poolCertVerifier) Pool() *x509.CertPool {
+	return n.pool
+}
+
+func (n * poolCertVerifier) AddCertificate(certificate *x509.Certificate) error {
+	n.pool.AddCert(certificate)
+	return nil
+}
+
+func (n poolCertVerifier) GetRoots(t time.Time) []*x509.Certificate {
+	panic("implement me")
+}
+
+func (n poolCertVerifier) GetCertificates(i [][]*x509.Certificate, t time.Time, b bool) [][]*x509.Certificate {
+	panic("implement me")
+}
+
 func (n poolCertVerifier) Verify(cert *x509.Certificate, moment time.Time) error {
 	if n.pool == nil {
 		return nil
@@ -474,8 +491,42 @@ func (n poolCertVerifier) Verify(cert *x509.Certificate, moment time.Time) error
 	return err
 }
 
-// Tests both JWSSignEphemeral and VerifyJWS functions
-func TestCrypto_JWSSignEphemeralAndVerify(t *testing.T) {
+func TestCrypto_SignJWS(t *testing.T) {
+	client := defaultBackend(t.Name())
+	defer emptyTemp(t.Name())
+	key := types.KeyForEntity(types.LegalEntity{URI: t.Name()})
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	_ = client.Storage.SavePrivateKey(key, privateKey)
+	t.Run("ok", func(t *testing.T) {
+		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageContentCommitment)
+		_ = client.Storage.SaveCertificate(key, certAsASN1)
+		dataToBeSigned := []byte("Hello, World!")
+		jwsAsBytes, err := client.SignJWS(dataToBeSigned, key)
+		if !assert.NoError(t, err) {
+			return
+		}
+		// Validate signature
+		payload, err := client.VerifyJWS(jwsAsBytes, time.Now(), client.trustStore)
+		assert.NoError(t, err)
+		assert.Equal(t, dataToBeSigned, payload)
+	})
+	t.Run("error - key/certificate missing", func(t *testing.T) {
+		jwsAsBytes, err := client.SignJWS([]byte{}, key.WithQualifier("non-existent"))
+		assert.EqualError(t, err, "signing certificate and/or private not present: [TestCrypto_SignJWS|non-existent]")
+		assert.Nil(t, jwsAsBytes)
+	})
+	t.Run("error - non signing certificate", func(t *testing.T) {
+		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageCRLSign)
+		_ = client.Storage.SaveCertificate(key, certAsASN1)
+		dataToBeSigned := []byte("Hello, World!")
+		jwsAsBytes, err := client.SignJWS(dataToBeSigned, key)
+		assert.EqualError(t, err, "certificate is not meant for signing (keyUsage = digitalSignature | contentCommitment)")
+		assert.Nil(t, jwsAsBytes)
+	})
+}
+
+// Tests both SignJWSEphemeral and VerifyJWS functions
+func TestCrypto_SignJWSEphemeralAndVerify(t *testing.T) {
 	client := defaultBackend(t.Name())
 	defer emptyTemp(t.Name())
 	selfSignCertificate := func(key types.KeyIdentifier, keyUsage x509.KeyUsage) *x509.Certificate {
@@ -554,7 +605,7 @@ func TestCrypto_JWSSignEphemeralAndVerify(t *testing.T) {
 		h.Set(jws.X509CertChainKey, cert.MarshalX509CertChain([]*x509.Certificate{certificate}))
 		sig, _ := jws.Sign(dataToBeSigned, jwsAlgorithm, privateKey, jws.WithHeaders(&h))
 		payload, err := client.VerifyJWS(sig, time.Now(), verifier)
-		assert.EqualError(t, err, "certificate is not meant for signing (keyUsage != digitalSignature)")
+		assert.EqualError(t, err, "certificate is not meant for signing (keyUsage = digitalSignature | contentCommitment)")
 		assert.Nil(t, payload)
 	})
 	t.Run("error - signature invalid (cert doesn't match signing key)", func(t *testing.T) {
@@ -589,7 +640,7 @@ func TestCrypto_JWSSignEphemeralAndVerify(t *testing.T) {
 	})
 	t.Run("error - key strength insufficient", func(t *testing.T) {
 		key, _ := rsa.GenerateKey(rand.Reader, 1024)
-		certBytes := test.GenerateCertificateEx(time.Now(), 2, key)
+		certBytes := test.GenerateCertificate(time.Now(), 2, key)
 		certificate, _ := x509.ParseCertificate(certBytes)
 		headers := jws.StandardHeaders{
 			JWSx509CertChain: cert.MarshalX509CertChain([]*x509.Certificate{certificate}),
@@ -686,7 +737,7 @@ func TestCrypto_StoreVendorCACertificate(t *testing.T) {
 	t.Run("ok - private key exists", func(t *testing.T) {
 		client.GenerateKeyPair(key)
 		privateKey, _ := client.GetPrivateKey(key)
-		certificateAsBytes := test.GenerateCertificateEx(time.Now(), 1, privateKey)
+		certificateAsBytes := test.GenerateCertificate(time.Now(), 1, privateKey)
 		certificate, _ := x509.ParseCertificate(certificateAsBytes)
 		err := client.StoreVendorCACertificate(certificate)
 		assert.NoError(t, err)
@@ -695,7 +746,7 @@ func TestCrypto_StoreVendorCACertificate(t *testing.T) {
 		client := defaultBackend(t.Name())
 		defer emptyTemp(t.Name())
 		privateKey, _ := client.generateKeyPair()
-		certificateAsBytes := test.GenerateCertificateEx(time.Now(), 1, privateKey)
+		certificateAsBytes := test.GenerateCertificate(time.Now(), 1, privateKey)
 		certificate, _ := x509.ParseCertificate(certificateAsBytes)
 		err := client.StoreVendorCACertificate(certificate)
 		assert.EqualError(t, err, "private key not present for key: [urn:oid:1.3.6.1.4.1.54851.4:123|]")
@@ -703,7 +754,7 @@ func TestCrypto_StoreVendorCACertificate(t *testing.T) {
 	t.Run("error - existing private key differs", func(t *testing.T) {
 		client.GenerateKeyPair(key)
 		privateKey, _ := client.GetPrivateKey(key)
-		certificateAsBytes := test.GenerateCertificateEx(time.Now(), 1, privateKey)
+		certificateAsBytes := test.GenerateCertificate(time.Now(), 1, privateKey)
 		certificate, _ := x509.ParseCertificate(certificateAsBytes)
 		client.GenerateKeyPair(key)
 		err := client.StoreVendorCACertificate(certificate)
@@ -750,7 +801,7 @@ func TestCrypto_GetSigningCertificate(t *testing.T) {
 	})
 	t.Run("ok - exists but expired", func(t *testing.T) {
 		privateKey, _ := client.generateAndStoreKeyPair(key.WithQualifier(signingCertificateQualifier))
-		certificateAsASN1 := test.GenerateCertificateEx(time.Now().AddDate(-1, 0, 0), 1, privateKey)
+		certificateAsASN1 := test.GenerateCertificate(time.Now().AddDate(-1, 0, 0), 1, privateKey)
 		client.Storage.SaveCertificate(key.WithQualifier(signingCertificateQualifier), certificateAsASN1)
 		certificate, pk, err := client.GetSigningCertificate(entity)
 		if !assert.NoError(t, err) {
@@ -763,7 +814,7 @@ func TestCrypto_GetSigningCertificate(t *testing.T) {
 		entity2 := types.LegalEntity{"foobar2"}
 		key2 := types.KeyForEntity(entity2)
 		privateKey, _ := client.generateKeyPair()
-		certificateAsASN1 := test.GenerateCertificateEx(time.Now(), 1, privateKey)
+		certificateAsASN1 := test.GenerateCertificate(time.Now(), 1, privateKey)
 		client.Storage.SaveCertificate(key2.WithQualifier(signingCertificateQualifier), certificateAsASN1)
 		certificate, pk, err := client.GetSigningCertificate(entity2)
 		assert.EqualError(t, err, "unable to retrieve private key for certificate: [foobar2|sign]: could not open entry [foobar2|sign] with filename temp/TestCrypto_GetSigningCertificate/Zm9vYmFyMg==_sign_private.pem: entry not found")
@@ -1013,8 +1064,8 @@ func TestCrypto_SignCertificate(t *testing.T) {
 	})
 
 	t.Run("error - signing certificate is not a CA certificate", func(t *testing.T) {
-		// Certificate created by GenerateCertificateEx is not a CA certificate
-		caCertificate := test.GenerateCertificateEx(time.Now(), 1, caPrivateKey)
+		// Certificate created by GenerateCertificate is not a CA certificate
+		caCertificate := test.GenerateCertificate(time.Now(), 1, caPrivateKey)
 		err := client.Storage.SaveCertificate(ca, caCertificate)
 		if !assert.NoError(t, err) {
 			return
@@ -1267,7 +1318,6 @@ func TestCrypto_Configure(t *testing.T) {
 		err := e.Configure()
 		assert.NoError(t, err)
 		// Assert server-mode services aren't initialized in client mode
-		assert.Nil(t, e.trustStore)
 		assert.Nil(t, e.Storage)
 	})
 	t.Run("error - keySize is too small", func(t *testing.T) {
@@ -1352,9 +1402,11 @@ func defaultBackend(name string) *Crypto {
 	if err := core.NutsConfig().Load(&cobra.Command{}); err != nil {
 		panic(err)
 	}
+	trustStore := poolCertVerifier{}
 	backend := Crypto{
-		Storage: createTempStorage(name),
-		Config:  DefaultCryptoConfig(),
+		Storage:    createTempStorage(name),
+		Config:     DefaultCryptoConfig(),
+		trustStore: &trustStore,
 	}
 
 	return &backend

--- a/pkg/interface.go
+++ b/pkg/interface.go
@@ -76,6 +76,11 @@ type Client interface {
 	GetPublicKeyAsJWK(key types.KeyIdentifier) (jwk.Key, error)
 	// SignJWT creates a signed JWT using the given key and map of claims (private key must be present).
 	SignJWT(claims map[string]interface{}, key types.KeyIdentifier) (string, error)
+	// SignJWS signs payload according to the JWS spec with the specified key. There must be both a private key and
+	// corresponding certificate be present for the given key, and the certificate must be meant for signing. If any of
+	// these preconditions fail, an error is returned.
+	// The certificate is included in the x509chain field of the resulting JWS.
+	SignJWS(payload []byte, key types.KeyIdentifier) ([]byte, error)
 	// SignJWSEphemeral signs payload according to the JWS spec with a temporary key and certificate which are generated just for this operation.
 	// In other words, the key and certificate are not stored and cannot be used for any other cryptographic operation.
 	// The certificate's validity is as short as possible, just spanning the instant of signing.
@@ -84,6 +89,8 @@ type Client interface {
 	//  csr:         Certificate Signing Request which is used for issuing the X.509 certificate which is included in the JWS.
 	//               The CSR indicates which entity (e.g. vendor, organization, etc) is signing the payload.
 	//  signingTime: instant which is checked later when verifying the signature. The certificate will just span this instant.
+	//
+	// Deprecated: we're moving away from ephemeral keys for JWS signing, so use SigJWS instead.
 	SignJWSEphemeral(payload []byte, caKey types.KeyIdentifier, csr x509.CertificateRequest, signingTime time.Time) ([]byte, error)
 	// VerifyJWS verifies a JWS ("signature"): it parses the JWS, checks if it's been signed with the expected algorithm,
 	// if it's signed with a certificate supplied in the "x5c" field of the JWS, if the certificate is trusted according

--- a/pkg/storage/fs_test.go
+++ b/pkg/storage/fs_test.go
@@ -193,7 +193,7 @@ func Test_fs_GetExpiringCertificates(t *testing.T) {
 
 	// expires in 8 days
 	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	storage.SaveCertificate(key, test.GenerateCertificateEx(time.Now().AddDate(0, 0, -1), 9, rsaKey))
+	storage.SaveCertificate(key, test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 9, rsaKey))
 
 	t.Run("Expiring certificate is found within correct period", func(t *testing.T) {
 		certs, err := storage.GetExpiringCertificates(time.Now(), time.Now().AddDate(0, 0, 14))

--- a/pkg/storage/metrics_test.go
+++ b/pkg/storage/metrics_test.go
@@ -126,7 +126,7 @@ func TestCertificateMonitor_checkExpiry(t *testing.T) {
 
 	t.Run("expiring certificate is count", func(t *testing.T) {
 		rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-		asn1 := test.GenerateCertificateEx(time.Now(), 1, rsaKey)
+		asn1 := test.GenerateCertificate(time.Now(), 1, rsaKey)
 		fs.SaveCertificate(types.KeyForEntity(types.LegalEntity{URI: "test"}), asn1)
 
 		m.checkExpiry()

--- a/test/cert.go
+++ b/test/cert.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func GenerateCertificateEx(notBefore time.Time, validityInDays int, privKey crypto.Signer) []byte {
+func GenerateCertificateEx(notBefore time.Time, privKey crypto.Signer, validityInDays int, isCA bool, keyUsage x509.KeyUsage) []byte {
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
@@ -18,7 +18,8 @@ func GenerateCertificateEx(notBefore time.Time, validityInDays int, privKey cryp
 		PublicKey:             privKey.Public(),
 		NotBefore:             notBefore,
 		NotAfter:              notBefore.AddDate(0, 0, validityInDays),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		IsCA:                  isCA,
+		KeyUsage:              keyUsage,
 		EmailAddresses:        []string{"test@test.nl"},
 		BasicConstraintsValid: true,
 	}
@@ -27,4 +28,8 @@ func GenerateCertificateEx(notBefore time.Time, validityInDays int, privKey cryp
 		panic(err)
 	}
 	return data
+}
+
+func GenerateCertificate(notBefore time.Time, validityInDays int, privKey crypto.Signer) []byte {
+	return GenerateCertificateEx(notBefore, privKey, validityInDays, false, x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature)
 }

--- a/test/mock/client.go
+++ b/test/mock/client.go
@@ -297,6 +297,21 @@ func (mr *MockClientMockRecorder) SignJWT(claims, key interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWT", reflect.TypeOf((*MockClient)(nil).SignJWT), claims, key)
 }
 
+// SignJWS mocks base method
+func (m *MockClient) SignJWS(payload []byte, key types.KeyIdentifier) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignJWS", payload, key)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignJWS indicates an expected call of SignJWS
+func (mr *MockClientMockRecorder) SignJWS(payload, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJWS", reflect.TypeOf((*MockClient)(nil).SignJWS), payload, key)
+}
+
 // SignJWSEphemeral mocks base method
 func (m *MockClient) SignJWSEphemeral(payload []byte, caKey types.KeyIdentifier, csr x509.CertificateRequest, signingTime time.Time) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Required for new certificate structure implementation, `registry` will sign with `Vendor Signing Certificate` rather than ephemeral certificate issued under Vendor or Organization certificate (current state).