### PR TITLE
Speedup tests using 1024 bits RSA keys instead of 2048

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -175,6 +175,8 @@ func TestApiWrapper_GenerateKeyPair(t *testing.T) {
 
 func TestApiWrapper_Encrypt(t *testing.T) {
 	client := apiWrapper()
+	crypto := client.C.(*pkg.Crypto)
+	crypto.Config.Keysize = pkg.MinKeySize // required for RSA OAEP encryption
 	defer emptyTemp()
 	plaintext := "for your eyes only"
 	client.C.GenerateKeyPair(key)
@@ -440,6 +442,8 @@ func TestApiWrapper_Encrypt(t *testing.T) {
 
 func TestApiWrapper_Decrypt(t *testing.T) {
 	client := apiWrapper()
+	crypto := client.C.(*pkg.Crypto)
+	crypto.Config.Keysize = pkg.MinKeySize // required for RSA OAEP encryption
 	defer emptyTemp()
 
 	plaintext := "for your eyes only"
@@ -1307,6 +1311,7 @@ func apiWrapper() *ApiWrapper {
 		Storage: createTempStorage(),
 		Config:  pkg.DefaultCryptoConfig(),
 	}
+	backend.Config.Keysize = 1024
 
 	return &ApiWrapper{C: &backend}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 )
 
@@ -23,6 +24,11 @@ func TestConfigureCryptoClient(t *testing.T) {
 		assert.IsType(t, api.HttpClient{}, client)
 	})
 	t.Run("error - panics for illegal config", func(t *testing.T) {
+		// Switch to strict mode just for this test
+		os.Setenv("NUTS_STRICTMODE", "true")
+		core.NutsConfig().Load(&cobra.Command{})
+		defer core.NutsConfig().Load(&cobra.Command{})
+		defer os.Unsetenv("NUTS_STRICTMODE")
 		instance := &pkg.Crypto{Config: pkg.DefaultCryptoConfig()}
 		instance.Config.Keysize = 1
 		assert.Panics(t, func() {

--- a/pkg/cert/util_test.go
+++ b/pkg/cert/util_test.go
@@ -19,7 +19,6 @@
 package cert
 
 import (
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -39,7 +38,7 @@ import (
 
 func TestCrypto_PublicKeyToPem(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		key, _ := rsa.GenerateKey(rand.Reader, 2048)
+		key := test.GenerateRSAKey()
 		result, err := PublicKeyToPem(&key.PublicKey)
 		if !assert.NoError(t, err) {
 			return
@@ -94,7 +93,7 @@ func TestCertificateToJWK(t *testing.T) {
 
 func TestJwkToMap(t *testing.T) {
 	t.Run("Generates map for RSA key", func(t *testing.T) {
-		rsa, _ := rsa.GenerateKey(rand.Reader, 1024)
+		rsa := test.GenerateRSAKey()
 		jwk, _ := jwk.New(rsa)
 
 		jwkMap, err := JwkToMap(jwk)
@@ -213,7 +212,7 @@ func TestMapToX509CertChain(t *testing.T) {
 
 func TestValidateCertificate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		rsaKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+		rsaKey := test.GenerateRSAKey()
 		asn1 := test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 2, rsaKey)
 		certificate, _ := x509.ParseCertificate(asn1)
 		assert.NoError(t, ValidateCertificate(certificate, ValidAt(time.Now())))
@@ -226,7 +225,7 @@ func TestValidateCertificate(t *testing.T) {
 
 func TestCopySANs(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		rsaKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+		rsaKey := test.GenerateRSAKey()
 		asn1 := test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 2, rsaKey)
 		certificate, _ := x509.ParseCertificate(asn1)
 		sans := CopySANs(certificate)
@@ -287,7 +286,7 @@ func TestValidateJWK(t *testing.T) {
 }
 
 func TestCertificateToPEM(t *testing.T) {
-	rsaKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	rsaKey := test.GenerateRSAKey()
 	asn1 := test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 2, rsaKey)
 	certificate, _ := x509.ParseCertificate(asn1)
 	pemEncoded := pem.EncodeToMemory(&pem.Block{
@@ -301,7 +300,7 @@ func TestCertificateToPEM(t *testing.T) {
 }
 
 func TestPemToX509(t *testing.T) {
-	rsaKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	rsaKey := test.GenerateRSAKey()
 	asn1 := test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 2, rsaKey)
 	pemEncoded := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
@@ -388,7 +387,7 @@ func TestIsCA(t *testing.T) {
 }
 
 func TestMeantForSigning(t *testing.T) {
-	privateKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	privateKey := test.GenerateRSAKey()
 	t.Run("invalid", func(t *testing.T) {
 		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageCertSign)
 		certificate, _ := x509.ParseCertificate(certAsASN1)
@@ -396,13 +395,13 @@ func TestMeantForSigning(t *testing.T) {
 		assert.EqualError(t, err, "certificate is not meant for signing (keyUsage = digitalSignature | contentCommitment)")
 	})
 	t.Run("valid (keyUsage = contentCommitment)", func(t *testing.T) {
-		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageContentCommitment | x509.KeyUsageKeyAgreement)
+		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageContentCommitment|x509.KeyUsageKeyAgreement)
 		certificate, _ := x509.ParseCertificate(certAsASN1)
 		err := MeantForSigning()(certificate)
 		assert.NoError(t, err)
 	})
 	t.Run("valid (keyUsage = digitalSignature)", func(t *testing.T) {
-		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign)
+		certAsASN1 := test.GenerateCertificateEx(time.Now(), privateKey, 1, false, x509.KeyUsageDigitalSignature|x509.KeyUsageCRLSign)
 		certificate, _ := x509.ParseCertificate(certAsASN1)
 		err := MeantForSigning()(certificate)
 		assert.NoError(t, err)

--- a/pkg/cert/x509_test.go
+++ b/pkg/cert/x509_test.go
@@ -1,8 +1,6 @@
 package cert
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
@@ -31,7 +29,7 @@ func Test_serialNumberUniqueness(t *testing.T) {
 }
 
 func TestGetActiveCertificates(t *testing.T) {
-	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	rsaKey := test.GenerateRSAKey()
 
 	t.Run("no keys", func(t *testing.T) {
 		certificates := GetActiveCertificates(make([]interface{}, 0), time.Now())

--- a/pkg/storage/fs_test.go
+++ b/pkg/storage/fs_test.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -100,7 +98,7 @@ func Test_fs_GetPublicKey(t *testing.T) {
 		assert.Nil(t, key)
 	})
 	t.Run("ok", func(t *testing.T) {
-		pk, _ := rsa.GenerateKey(rand.Reader, 2048)
+		pk := test.GenerateRSAKey()
 		err := storage.SavePrivateKey(key, pk)
 		if !assert.NoError(t, err) {
 			return
@@ -135,7 +133,7 @@ func Test_fs_GetPrivateKey(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("ok", func(t *testing.T) {
-		pk, _ := rsa.GenerateKey(rand.Reader, 2048)
+		pk := test.GenerateRSAKey()
 		err := storage.SavePrivateKey(key, pk)
 		if !assert.NoError(t, err) {
 			return
@@ -157,7 +155,7 @@ func Test_fs_KeyExistsFor(t *testing.T) {
 		assert.False(t, storage.PrivateKeyExists(key))
 	})
 	t.Run("existing entry", func(t *testing.T) {
-		privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		privateKey := test.GenerateRSAKey()
 		storage.SavePrivateKey(key, privateKey)
 		assert.True(t, storage.PrivateKeyExists(key))
 	})
@@ -192,7 +190,7 @@ func Test_fs_GetExpiringCertificates(t *testing.T) {
 	defer emptyTemp(t.Name())
 
 	// expires in 8 days
-	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	rsaKey := test.GenerateRSAKey()
 	storage.SaveCertificate(key, test.GenerateCertificate(time.Now().AddDate(0, 0, -1), 9, rsaKey))
 
 	t.Run("Expiring certificate is found within correct period", func(t *testing.T) {

--- a/pkg/storage/metrics_test.go
+++ b/pkg/storage/metrics_test.go
@@ -19,8 +19,6 @@
 package storage
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"testing"
 	"time"
 
@@ -125,7 +123,7 @@ func TestCertificateMonitor_checkExpiry(t *testing.T) {
 	})
 
 	t.Run("expiring certificate is count", func(t *testing.T) {
-		rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		rsaKey := test.GenerateRSAKey()
 		asn1 := test.GenerateCertificate(time.Now(), 1, rsaKey)
 		fs.SaveCertificate(types.KeyForEntity(types.LegalEntity{URI: "test"}), asn1)
 

--- a/test/keys.go
+++ b/test/keys.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+func GenerateRSAKey() *rsa.PrivateKey {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic(err)
+	}
+	return privateKey
+}


### PR DESCRIPTION
This speeds up the unit test 300% on my machine. Also allows dependent engines (like `nuts-registry`) to speed up their tests as well (since `registry`'s tests are really slow).