### PR TITLE
Fix CertificateMonitor null dereference

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,24 +25,17 @@ import (
 
 	"github.com/nuts-foundation/nuts-crypto/api"
 	"github.com/nuts-foundation/nuts-crypto/pkg"
-	"github.com/sirupsen/logrus"
 )
 
 // NewCryptoClient creates a new local or remote client, depending on engine configuration.
 func NewCryptoClient() pkg.Client {
-	return configureClient(pkg.CryptoInstance(), core.NutsConfig())
-}
-
-func configureClient(cryptoClient *pkg.Crypto, globalConfig core.NutsConfigValues) pkg.Client {
-	if globalConfig.GetEngineMode(cryptoClient.Config.Mode) == core.ServerEngineMode {
-		if err := cryptoClient.Configure(); err != nil {
-			logrus.Panic(err)
-		}
-		return cryptoClient
+	instance := pkg.CryptoInstance()
+	if core.NutsConfig().GetEngineMode(instance.Config.Mode) == core.ServerEngineMode {
+		return instance
 	} else {
 		return api.HttpClient{
-			ServerAddress: cryptoClient.Config.Address,
-			Timeout:       time.Duration(cryptoClient.Config.ClientTimeout) * time.Second,
+			ServerAddress: instance.Config.Address,
+			Timeout:       time.Duration(instance.Config.ClientTimeout) * time.Second,
 		}
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,60 +4,21 @@ import (
 	"github.com/nuts-foundation/nuts-crypto/api"
 	"github.com/nuts-foundation/nuts-crypto/pkg"
 	core "github.com/nuts-foundation/nuts-go-core"
-	"github.com/nuts-foundation/nuts-go-test/io"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 )
 
-func TestConfigureCryptoClient(t *testing.T) {
-	t.Run("ok - server mode", func(t *testing.T) {
-		globalConfig := core.NewNutsGlobalConfig()
-		globalConfig.Load(&cobra.Command{})
-		client := configureClient(pkg.NewTestCryptoInstance(io.TestDirectory(t)), globalConfig)
-		assert.NotNil(t, client)
-		assert.IsType(t, &pkg.Crypto{}, client)
-	})
-	t.Run("ok - CLI mode", func(t *testing.T) {
-		client := configureClient(&pkg.Crypto{Config: pkg.TestCryptoConfig(io.TestDirectory(t))}, testConfig{})
-		assert.NotNil(t, client)
-		assert.IsType(t, api.HttpClient{}, client)
-	})
-	t.Run("error - panics for illegal config", func(t *testing.T) {
-		// Switch to strict mode just for this test
-		os.Setenv("NUTS_STRICTMODE", "true")
-		core.NutsConfig().Load(&cobra.Command{})
-		defer core.NutsConfig().Load(&cobra.Command{})
-		defer os.Unsetenv("NUTS_STRICTMODE")
-		instance := &pkg.Crypto{Config: pkg.TestCryptoConfig(io.TestDirectory(t))}
-		instance.Config.Keysize = 1
-		assert.Panics(t, func() {
-			configureClient(instance, core.NutsConfig())
-		})
-	})
+func TestNewCryptoClient_ServerMode(t *testing.T) {
+	_, ok := NewCryptoClient().(*pkg.Crypto)
+	assert.True(t, ok)
 }
 
-type testConfig struct {
-
-}
-
-func (t testConfig) ServerAddress() string {
-	panic("implement me")
-}
-
-func (t testConfig) InStrictMode() bool {
-	panic("implement me")
-}
-
-func (t testConfig) Mode() string {
-	panic("implement me")
-}
-
-func (t testConfig) Identity() string {
-	panic("implement me")
-}
-
-func (t testConfig) GetEngineMode(engineMode string) string {
-	return "client"
+func TestNewCryptoClient_ClientMode(t *testing.T) {
+	os.Setenv("NUTS_MODE", "cli")
+	defer os.Unsetenv("NUTS_MODE")
+	core.NutsConfig().Load(&cobra.Command{})
+	_, ok := NewCryptoClient().(api.HttpClient)
+	assert.True(t, ok)
 }

--- a/pkg/crypto.go
+++ b/pkg/crypto.go
@@ -406,6 +406,9 @@ var instance *Crypto
 var oneBackend sync.Once
 
 func CryptoInstance() *Crypto {
+	if instance != nil {
+		return instance
+	}
 	oneBackend.Do(func() {
 		instance = NewCryptoInstance(DefaultCryptoConfig())
 	})

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -73,6 +73,9 @@ type fileSystemBackend struct {
 // Create a new filesystem backend, all directories will be created for the given path
 // Using a filesystem backend in production is not recommended!
 func NewFileSystemBackend(fspath string) (*fileSystemBackend, error) {
+	if fspath == "" {
+		return nil, errors.New("filesystem path is empty")
+	}
 	fsc := &fileSystemBackend{
 		fspath,
 	}

--- a/pkg/storage/fs_test.go
+++ b/pkg/storage/fs_test.go
@@ -89,6 +89,14 @@ func Test_fs_GetCertificate(t *testing.T) {
 	})
 }
 
+func Test_NewFileSystemBackend(t *testing.T) {
+	t.Run("error - path is empty", func(t *testing.T) {
+		storage, err := NewFileSystemBackend("")
+		assert.EqualError(t, err, "filesystem path is empty")
+		assert.Nil(t, storage)
+	})
+}
+
 func Test_fs_GetPublicKey(t *testing.T) {
 	t.Run("non-existing entry", func(t *testing.T) {
 		storage, _ := NewFileSystemBackend(io.TestDirectory(t))


### PR DESCRIPTION
When other engines retrieve a client for crypto using `NewCryptoClient` during `register engines` phase `Configure()` was called on the crypto instance. Since at that time the configuration isn't injected yet, the storage backend defaulted to `./` as location, which resolved to root (`/`) in the Nuts Service Space Docker container. Because of that the complete filesystem of the Docker container was walked when `GetExpiringCertificates()` was called by the scheduled metrics after 15 minutes of uptime, leading to a strange null dereference (which shouldn't be able to happen when reading `files.Walk`'s source and documentation) in the walker callback.

Fix is to not configure the instance during engine/client creation, but let `nuts-go` call `Configure()`. This might pose a problem when run in client mode however, but only when there are configuration actions only applicable when in client mode (which there currently aren't).

Note: this PR is based on https://github.com/nuts-foundation/nuts-crypto/pull/81 so that one should be merged first.