### PR TITLE
Added helpers for JWT validation

### DIFF
--- a/pkg/cert/truststore.go
+++ b/pkg/cert/truststore.go
@@ -18,6 +18,7 @@ type Verifier interface {
 	// Verify verifies the given certificate. The validity of the certificate is checked against the given moment in time.
 	Verify(*x509.Certificate, time.Time) error
 	// VerifiedChain verifies the certificate against the truststore and returns the chain of trust as result
+	// multiple chains can apply but this should only happen when the VendorCA was renewed (overlapping certs)
 	VerifiedChain(*x509.Certificate, time.Time) ([][]*x509.Certificate, error)
 }
 

--- a/pkg/cert/truststore.go
+++ b/pkg/cert/truststore.go
@@ -17,6 +17,8 @@ import (
 type Verifier interface {
 	// Verify verifies the given certificate. The validity of the certificate is checked against the given moment in time.
 	Verify(*x509.Certificate, time.Time) error
+	// VerifiedChain verifies the certificate against the truststore and returns the chain of trust as result
+	VerifiedChain(*x509.Certificate, time.Time) ([][]*x509.Certificate, error)
 }
 
 type TrustStore interface {
@@ -199,6 +201,10 @@ func exists(file string) (bool, error) {
 func (m fileTrustStore) Verify(cert *x509.Certificate, moment time.Time) error {
 	_, err := cert.Verify(x509.VerifyOptions{Roots: m.pool, CurrentTime: moment})
 	return err
+}
+
+func (m fileTrustStore) VerifiedChain(cert *x509.Certificate, moment time.Time) ([][]*x509.Certificate, error) {
+	return cert.Verify(x509.VerifyOptions{Roots: m.pool, CurrentTime: moment})
 }
 
 func findBlocksInPEM(data []byte, blockType string) ([]*pem.Block, error) {

--- a/pkg/cert/truststore_test.go
+++ b/pkg/cert/truststore_test.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"github.com/nuts-foundation/nuts-crypto/test"
-	"github.com/nuts-foundation/nuts-go-test/io"
 	"os"
 	"path"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/nuts-foundation/nuts-crypto/test"
+	"github.com/nuts-foundation/nuts-go-test/io"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -166,6 +167,22 @@ func Test_fileTrustStore_Verify(t *testing.T) {
 		trustStore, _ := NewTrustStore("../../test/truststore.pem")
 		err := trustStore.Verify((trustStore.(*fileTrustStore)).certs[0], time.Unix(2000, 0))
 		assert.Error(t, err)
+	})
+}
+
+func Test_fileTrustStore_VerifiedChain(t *testing.T) {
+	t.Run("ok - valid", func(t *testing.T) {
+		trustStore, _ := NewTrustStore("../../test/truststore.pem")
+		chain, err := trustStore.VerifiedChain((trustStore.(*fileTrustStore)).certs[0], time.Now())
+		assert.NoError(t, err)
+		assert.Len(t, chain, 1)
+		assert.Len(t, chain[0], 1)
+	})
+	t.Run("ok - not valid", func(t *testing.T) {
+		trustStore, _ := NewTrustStore("../../test/truststore.pem")
+		chain, err := trustStore.VerifiedChain((trustStore.(*fileTrustStore)).certs[0], time.Unix(2000, 0))
+		assert.Error(t, err)
+		assert.Nil(t, chain)
 	})
 }
 

--- a/pkg/cert/x509.go
+++ b/pkg/cert/x509.go
@@ -111,3 +111,28 @@ func UnmarshalNutsDomain(data []byte) (string, error) {
 	}
 	return string(value.Bytes), nil
 }
+
+var ErrSANNotFound = errors.New("subject alternative name not found")
+
+// VendorIDFromCertificate returns the Nuts Vendor ID from a certificate.
+func VendorIDFromCertificate(certificate *x509.Certificate) (string, error) {
+	// extract SAN
+
+	for _, e := range certificate.Extensions {
+		if e.Id.Equal(OIDSubjectAltName) {
+			return UnmarshalOtherSubjectAltName(OIDNutsVendor, e.Value)
+		}
+	}
+	return "", ErrSANNotFound
+}
+
+// DomainFromCertificate finds the Nuts domain without the OID, just the value
+func DomainFromCertificate(certificate *x509.Certificate) (string, error) {
+	// extract SAN
+	for _, e := range certificate.Extensions {
+		if e.Id.Equal(OIDNutsDomain) {
+			return UnmarshalNutsDomain(e.Value)
+		}
+	}
+	return "", ErrSANNotFound
+}

--- a/pkg/jwx_test.go
+++ b/pkg/jwx_test.go
@@ -156,7 +156,6 @@ func TestCrypto_SignJwtFor(t *testing.T) {
 
 func TestCrypto_SignJWS(t *testing.T) {
 	client := createCrypto(t)
-	createCrypto(t)
 
 	key := types.KeyForEntity(types.LegalEntity{URI: t.Name()})
 	privateKey := test.GenerateRSAKey()

--- a/pkg/x509_test.go
+++ b/pkg/x509_test.go
@@ -662,7 +662,8 @@ func TestCrypto_generateVendorEphemeralSigningCertificate(t *testing.T) {
 		t.Run("verify VendorID SAN", func(t *testing.T) {
 			vendorId, err := cert.VendorIDFromCertificate(certificate)
 			assert.NoError(t, err)
-			assert.Equal(t, "123", vendorId)
+			assert.Equal(t, "123", vendorId.Value())
+			assert.Equal(t, core.NutsVendorOID, vendorId.OID())
 		})
 		t.Run("verify Domain extension", func(t *testing.T) {
 			domain, err := cert.DomainFromCertificate(certificate)
@@ -674,7 +675,6 @@ func TestCrypto_generateVendorEphemeralSigningCertificate(t *testing.T) {
 
 func TestCrypto_generateVendorEphemeralSigningCertificate2(t *testing.T) {
 	client := createCrypto(t)
-	client.SelfSignVendorCACertificate("test")
 	ca := key
 	client.GenerateKeyPair(ca, false)
 


### PR DESCRIPTION
Added verifiedChain func to TrustStore. This will allow the JWT verification to get the whole chain

Added helper methods for extracting vendor Id from certificate. This will help validating JWT's where the signing certificate must have the same vendorID as the issuer.